### PR TITLE
DGFParser: avoid SGrid deprecation warning.

### DIFF
--- a/ewoms/common/start.hh
+++ b/ewoms/common/start.hh
@@ -35,7 +35,7 @@
 #include <ewoms/common/simulator.hh>
 #include <ewoms/common/timer.hh>
 
-#include <dune/grid/io/file/dgfparser.hh>
+#include <dune/grid/io/file/dgfparser/dgfparser.hh>
 #include <dune/common/parametertreeparser.hh>
 
 #include <fstream>

--- a/ewoms/io/dgfgridmanager.hh
+++ b/ewoms/io/dgfgridmanager.hh
@@ -25,7 +25,7 @@
 
 #include <ewoms/parallel/mpihelper.hh>
 
-#include <dune/grid/io/file/dgfparser.hh>
+#include <dune/grid/io/file/dgfparser/dgfparser.hh>
 
 #include <ewoms/io/basegridmanager.hh>
 #include <opm/core/utility/PropertySystem.hpp>

--- a/tests/problems/richardslensproblem.hh
+++ b/tests/problems/richardslensproblem.hh
@@ -33,7 +33,7 @@
 #include <opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 
-#include <dune/grid/io/file/dgfparser.hh>
+#include <dune/grid/io/file/dgfparser/dgfyasp.hh>
 
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>


### PR DESCRIPTION
This should remove the SGrid deprecation warning. It compiles with the 2.3.1. version of DUNE, so it should compile with the trunk.
