### PR TITLE
Check each command line parameter for a correctly specified value

### DIFF
--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -720,6 +720,16 @@ std::string parseCommandLineOptions(int argc,
         }
         seenKeys.insert(paramName);
 
+        if (s.empty() || s[0] != '=' || s.size()==1) {
+            std::string msg =
+                std::string("Parameter '")+paramName+"' is missing a value. "
+                +" Please use "+argv[i]+"=value.";
+
+            if (!helpPreamble.empty())
+                printUsage<TypeTag>(helpPreamble, msg, std::cerr);
+            return msg;
+        }
+
         paramValue = s.substr(1);
 
         // Put the key=value pair into the parameter tree


### PR DESCRIPTION
and print a meaningful error message. ewoms expects the format
--param=value. Some users might be used to --param value and will
get an exception thrown when using it.

Without this running 'flow --output-dir dir SPE1CASE2' results in the
rather cryptic message (when compiled wih debugging symbols, otherwise
it should be even less usable):

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::substr: __pos (which is 1) > this->size() (which is 0)
[smaug:111393] *** Process received signal ***
[smaug:111393] Signal: Aborted (6)
[smaug:111393] Signal code:  (-6)
[smaug:111393] [ 0] /lib/x86_64-linux-gnu/libpthread.so.0(+0x12730)[0x7f8172fe3730]
[smaug:111393] [ 1] /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x10b)[0x7f817119c7bb]
[smaug:111393] [ 2] /lib/x86_64-linux-gnu/libc.so.6(abort+0x121)[0x7f8171187535]
[smaug:111393] [ 3] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0x8c983)[0x7f81713ff983]
[smaug:111393] [ 4] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0x928c6)[0x7f81714058c6]
[smaug:111393] [ 5] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0x92901)[0x7f8171405901]
[smaug:111393] [ 6] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0x92b34)[0x7f8171405b34]
[smaug:111393] [ 7] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0x8e891)[0x7f8171401891]
[smaug:111393] [ 8] /usr/lib/x86_64-linux-gnu/libstdc++.so.6(_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6substrEmm+0x57)[0x7f8171493767]
[smaug:111393] [ 9] ../../opm-simulators/opm-parallel-debug/bin/flow(_ZN5Ewoms10Parameters23parseCommandLineOptionsINS_10Properties4TTag13FlowEarlyBirdEFiRSt3setINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4lessISB_ESaISB_EERSB_iPPKciiEEESB_iSK_RKSB_RKT0_+0x7f3)[0x5646ea539642]
[smaug:111393] [10] ../../opm-simulators/opm-parallel-debug/bin/flow(+0x1579a9b)[0x5646ea530a9b]
[smaug:111393] [11] ../../opm-simulators/opm-parallel-debug/bin/flow(_ZN3Opm12FlowMainEbosIN5Ewoms10Properties4TTag13FlowEarlyBirdEE16setupParameters_EiPPc+0x1e5)[0x5646ea525171]
[smaug:111393] [12] ../../opm-simulators/opm-parallel-debug/bin/flow(main+0xfa)[0x5646ea4e1c95]
[smaug:111393] [13] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xeb)[0x7f817118909b]
[smaug:111393] [14] ../../opm-simulators/opm-parallel-debug/bin/flow(_start+0x2a)[0x5646ea4e11ca]
[smaug:111393] *** End of error message ***
```