### PR TITLE
Fixes g++-8's problems with return type deduction (ALUGrid master). (backport #570)

### DIFF
--- a/tests/test_quadrature.cc
+++ b/tests/test_quadrature.cc
@@ -188,12 +188,10 @@ void testTetrahedron()
     std::vector<unsigned int> v = { 0, 1, 2, 3 };
     // in Dune >= 2.6 topologyIds seem to be opaque integers. WTF!?
     gf.insertElement(Dune::GeometryType(/*topologyId=*/0, dim), v);
-    auto *grid = gf.createGrid();
+    const auto& grid = *gf.createGrid();
 
     // write the sub-control volumes to a VTK file.
-    writeTetrahedronSubControlVolumes(*grid);
-
-    delete grid;
+    writeTetrahedronSubControlVolumes(grid);
 #endif // HAVE_DUNE_ALUGRID
 }
 
@@ -283,12 +281,10 @@ void testCube()
     std::vector<unsigned int> v = { 0, 1, 2, 3, 4, 5, 6, 7 };
     // in Dune >= 2.6 topologyIds seem to be opaque integers. WTF!?
     gf.insertElement(Dune::GeometryType((1 << dim) - 1, dim), v);
-    auto *grid = gf.createGrid();
+    const auto& grid = *gf.createGrid();
 
     // write the sub-control volumes to a VTK file.
-    writeCubeSubControlVolumes(*grid);
-
-    delete grid;
+    writeCubeSubControlVolumes(grid);
 #endif // HAVE_DUNE_ALUGRID
 }
 


### PR DESCRIPTION
Fixes the following compile error in the tests for ALUGrid master.
Tested with DUNE 2.4-2.7
```
/home/mblatt/src/dune/opm-release-master/opm-models/tests/test_quadrature.cc: In function ‘void testTetrahedron()’:
/home/mblatt/src/dune/opm-release-master/opm-models/tests/test_quadrature.cc:191:32: error: unable to deduce ‘auto*’ from ‘Dune::ALU3dGridFactory< <template-parameter-1-1> >::createGrid() [with ALUGrid = Dune::ALUGrid<3, 3, (Dune::ALUGridElementType)0, (Dune::ALUGridRefinementType)1>; Dune::ALU3dGridFactory< <template-parameter-1-1> >::GridPtrType = Dune::ToUniquePtr<Dune::ALUGrid<3, 3, (Dune::ALUGridElementType)0, (Dune::ALUGridRefinementType)1> >]()’
     auto *grid = gf.createGrid();
                                ^
/home/mblatt/src/dune/opm-release-master/opm-models/tests/test_quadrature.cc:191:32: note:   mismatched types ‘auto*’ and ‘Dune::ToUniquePtr<Dune::ALUGrid<3, 3, (Dune::ALUGridElementType)0, (Dune::ALUGridRefinementType)1> >’
/home/mblatt/src/dune/opm-release-master/opm-models/tests/test_quadrature.cc:196:12: error: type ‘<type error>’ argument given to ‘delete’, expected pointer
     delete grid;
            ^~~~
/home/mblatt/src/dune/opm-release-master/opm-models/tests/test_quadrature.cc: In function ‘void testCube()’:
/home/mblatt/src/dune/opm-release-master/opm-models/tests/test_quadrature.cc:286:32: error: unable to deduce ‘auto*’ from ‘Dune::ALU3dGridFactory< <template-parameter-1-1> >::createGrid() [with ALUGrid = Dune::ALUGrid<3, 3, (Dune::ALUGridElementType)1, (Dune::ALUGridRefinementType)1>; Dune::ALU3dGridFactory< <template-parameter-1-1> >::GridPtrType = Dune::ToUniquePtr<Dune::ALUGrid<3, 3, (Dune::ALUGridElementType)1, (Dune::ALUGridRefinementType)1> >]()’
     auto *grid = gf.createGrid();
                                ^
/home/mblatt/src/dune/opm-release-master/opm-models/tests/test_quadrature.cc:286:32: note:   mismatched types ‘auto*’ and ‘Dune::ToUniquePtr<Dune::ALUGrid<3, 3, (Dune::ALUGridElementType)1, (Dune::ALUGridRefinementType)1> >’
/home/mblatt/src/dune/opm-release-master/opm-models/tests/test_quadrature.cc:291:12: error: type ‘<type error>’ argument given to ‘delete’, expected pointer
     delete grid;
            ^~~~
```