### PR TITLE
Move BlackOilOnePhaseIndices to Opm namespace

### DIFF
--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -158,6 +158,6 @@ struct BlackOilOnePhaseIndices
         enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers + numFoam : -1000;
 };
 
-} // namespace Ewoms
+} // namespace Opm
 
 #endif

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -30,7 +30,7 @@
 
 #include <cassert>
 
-namespace Ewoms {
+namespace Opm {
 
 /*!
  * \ingroup BlackOilModel

--- a/opm/simulators/linalg/combinedcriterion.hh
+++ b/opm/simulators/linalg/combinedcriterion.hh
@@ -237,6 +237,6 @@ private:
 
 //! \} end documentation
 
-}} // end namespace Linear,Ewoms
+}} // end namespace Linear, Opm
 
 #endif

--- a/opm/simulators/linalg/convergencecriterion.hh
+++ b/opm/simulators/linalg/convergencecriterion.hh
@@ -151,6 +151,6 @@ public:
 
 //! \} end documentation
 
-}} // end namespace Linear, Ewoms
+}} // end namespace Linear, Opm
 
 #endif

--- a/opm/simulators/linalg/fixpointcriterion.hh
+++ b/opm/simulators/linalg/fixpointcriterion.hh
@@ -180,6 +180,6 @@ private:
 
 //! \} end documentation
 
-}} // end namespace Linear, Ewoms
+}} // end namespace Linear, Opm
 
 #endif

--- a/opm/simulators/linalg/istlpreconditionerwrappers.hh
+++ b/opm/simulators/linalg/istlpreconditionerwrappers.hh
@@ -200,6 +200,6 @@ EWOMS_WRAP_ISTL_PRECONDITIONER(ILUn, Dune::SeqILUn)
 #endif
 
 #undef EWOMS_WRAP_ISTL_PRECONDITIONER
-}} // namespace Linear, Ewoms
+}} // namespace Linear, Opm
 
 #endif

--- a/opm/simulators/linalg/istlsolverwrappers.hh
+++ b/opm/simulators/linalg/istlsolverwrappers.hh
@@ -175,6 +175,6 @@ private:
 
 #undef EWOMS_WRAP_ISTL_SOLVER
 
-}} // namespace Linear, Ewoms
+}} // namespace Linear, Opm
 
 #endif

--- a/opm/simulators/linalg/istlsparsematrixadapter.hh
+++ b/opm/simulators/linalg/istlsparsematrixadapter.hh
@@ -192,6 +192,6 @@ protected:
     std::unique_ptr<IstlMatrix> istlMatrix_;
 };
 
-}} // namespace Linear, Ewoms
+}} // namespace Linear, Opm
 
 #endif

--- a/opm/simulators/linalg/linearsolverreport.hh
+++ b/opm/simulators/linalg/linearsolverreport.hh
@@ -78,6 +78,6 @@ private:
     bool converged_;
 };
 
-}} // end namespace Linear, Ewoms
+}} // end namespace Linear, Opm
 
 #endif

--- a/opm/simulators/linalg/parallelbasebackend.hh
+++ b/opm/simulators/linalg/parallelbasebackend.hh
@@ -444,7 +444,7 @@ protected:
 
     PreconditionerWrapper precWrapper_;
 };
-}} // namespace Linear, Ewoms
+}} // namespace Linear, Opm
 
 BEGIN_PROPERTIES
 

--- a/opm/simulators/linalg/parallelbicgstabbackend.hh
+++ b/opm/simulators/linalg/parallelbicgstabbackend.hh
@@ -38,7 +38,7 @@ namespace Opm {
 namespace Linear {
 template <class TypeTag>
 class ParallelBiCGStabSolverBackend;
-}} // namespace Linear, Ewoms
+}} // namespace Linear, Opm
 
 BEGIN_PROPERTIES
 
@@ -165,6 +165,6 @@ protected:
     std::unique_ptr<ConvergenceCriterion<OverlappingVector> > convCrit_;
 };
 
-}} // namespace Linear, Ewoms
+}} // namespace Linear, Opm
 
 #endif

--- a/opm/simulators/linalg/parallelistlbackend.hh
+++ b/opm/simulators/linalg/parallelistlbackend.hh
@@ -143,7 +143,7 @@ protected:
     LinearSolverWrapper solverWrapper_;
 };
 
-}} // namespace Linear, Ewoms
+}} // namespace Linear, Opm
 
 BEGIN_PROPERTIES
 

--- a/opm/simulators/linalg/residreductioncriterion.hh
+++ b/opm/simulators/linalg/residreductioncriterion.hh
@@ -147,6 +147,6 @@ private:
 
 //! \} end documentation
 
-}} // end namespace Linear,Ewoms
+}} // end namespace Linear, Opm
 
 #endif

--- a/opm/simulators/linalg/weightedresidreductioncriterion.hh
+++ b/opm/simulators/linalg/weightedresidreductioncriterion.hh
@@ -315,6 +315,6 @@ private:
 
 //! \} end documentation
 
-}} // end namespace Linear,Ewoms
+}} // end namespace Linear, Opm
 
 #endif


### PR DESCRIPTION
to make it consistent with the rest. #530 development must have been started before the renaming in #532 and somehow the old namespace survived.

Downstream PR is coming.