### PR TITLE
Use DeckItem::hasValue() before accessing Todd Langstaff parameters

### DIFF
--- a/opm/models/blackoil/blackoilsolventmodules.hh
+++ b/opm/models/blackoil/blackoilsolventmodules.hh
@@ -294,16 +294,18 @@ public:
 
                 for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
                     const auto& tlmixparRecord = deck.getKeyword("TLMIXPAR").getRecord(regionIdx);
-                    const auto& mixParamsViscosity = tlmixparRecord.getItem("TL_VISCOSITY_PARAMETER").getSIDoubleData();
-                    tlMixParamViscosity_[regionIdx] = mixParamsViscosity[0];
-                    const auto& mixParamsDensity = tlmixparRecord.getItem("TL_DENSITY_PARAMETER").getSIDoubleData();
-                    const int numDensityItems = mixParamsDensity.size();
-                    if (numDensityItems == 0)
-                        tlMixParamDensity_[regionIdx] = tlMixParamViscosity_[regionIdx];
-                    else if (numDensityItems == 1)
-                        tlMixParamDensity_[regionIdx] = mixParamsDensity[0];
+                    const auto& mixParamsViscosityItem  = tlmixparRecord.getItem("TL_VISCOSITY_PARAMETER");
+                    const auto& mixParamsDensityItem    = tlmixparRecord.getItem("TL_DENSITY_PARAMETER");
+
+                    if (mixParamsViscosityItem.hasValue(0))
+                        tlMixParamViscosity_[regionIdx] = mixParamsViscosityItem.getSIDouble(0);
                     else
-                        throw std::runtime_error("Only one value can be entered for the TL parameter pr MISC region.");
+                        throw std::invalid_argument("The TL_VISCOSITY parameter can not be defaulted");
+
+                    if (mixParamsDensityItem.hasValue(0))
+                        tlMixParamDensity_[regionIdx] = mixParamsDensityItem.getSIDouble(0);
+                    else
+                        tlMixParamDensity_[regionIdx] = tlMixParamViscosity_[regionIdx];
                 }
             }
             else


### PR DESCRIPTION
While working on refactoring defaults - to refactor the 3D system I encountered this problem. There is bug/feature in the `DeckItem::getData()` function which is easy to get fooled by. The opm-common Deck data structures try quite hard to keep control over what data is assigned/defautled/and... and so on - but by using:
```
std::vector<T> data& = deck_item::getData<T>(0);
```
you can bypass virtually all checks and get invalid data[1]. When things were refactor the code addressed in this PR produced undefined values.

This PR can (and should!) be merged right away - indepent of the ongoing efforts in opm-common; but it must be merged before/along with https://github.com/OPM/opm-common/pull/1230.

[1]: This is being tightened up. 