### PR TITLE
Add serialization templates

### DIFF
--- a/opm/models/blackoil/blackoilfoammodules.hh
+++ b/opm/models/blackoil/blackoilfoammodules.hh
@@ -443,6 +443,81 @@ public:
         return foamCoefficients_[satnumRegionIdx];
     }
 
+    template<class Serializer>
+    static std::size_t packSize(Serializer& serializer)
+    {
+        std::size_t size = serializer.packSize(foamRockDensity_) +
+                           serializer.packSize(foamAllowDesorption_) +
+                           serializer.packSize(adsorbedFoamTable_) +
+                           serializer.packSize(gasMobilityMultiplierTable_);
+        size += serializer.packSize(foamCoefficients_.size());
+        for (const auto& it : foamCoefficients_) {
+            size += serializer.packSize(it.fm_min);
+            size += serializer.packSize(it.fm_mob);
+            size += serializer.packSize(it.fm_surf);
+            size += serializer.packSize(it.ep_surf);
+            size += serializer.packSize(it.fm_oil);
+            size += serializer.packSize(it.fl_oil);
+            size += serializer.packSize(it.ep_oil);
+            size += serializer.packSize(it.fm_cap);
+            size += serializer.packSize(it.ep_cap);
+            size += serializer.packSize(it.fm_dry);
+            size += serializer.packSize(it.ep_dry);
+        }
+
+        return size;
+    }
+
+    template<class Serializer>
+    static void pack(std::vector<char>& buffer, int& position,
+                     Serializer& serializer)
+    {
+        serializer.pack(foamRockDensity_, buffer, position);
+        serializer.pack(foamAllowDesorption_, buffer, position);
+        serializer.pack(adsorbedFoamTable_, buffer, position);
+        serializer.pack(gasMobilityMultiplierTable_, buffer, position);
+        serializer.pack(foamCoefficients_.size(), buffer, position);
+        for (const auto& it : foamCoefficients_) {
+            serializer.pack(it.fm_min, buffer, position);
+            serializer.pack(it.fm_mob, buffer, position);
+            serializer.pack(it.fm_surf, buffer, position);
+            serializer.pack(it.ep_surf, buffer, position);
+            serializer.pack(it.fm_oil, buffer, position);
+            serializer.pack(it.fl_oil, buffer, position);
+            serializer.pack(it.ep_oil, buffer, position);
+            serializer.pack(it.fm_cap, buffer, position);
+            serializer.pack(it.ep_cap, buffer, position);
+            serializer.pack(it.fm_dry, buffer, position);
+            serializer.pack(it.ep_dry, buffer, position);
+        }
+    }
+
+    template<class Serializer>
+    static void unpack(std::vector<char>& buffer, int& position,
+                       Serializer& serializer)
+    {
+        serializer.unpack(foamRockDensity_, buffer, position);
+        serializer.unpack(foamAllowDesorption_, buffer, position);
+        serializer.unpack(adsorbedFoamTable_, buffer, position);
+        serializer.unpack(gasMobilityMultiplierTable_, buffer, position);
+        size_t size;
+        serializer.unpack(size, buffer, position);
+        foamCoefficients_.resize(size);
+        for (auto& it : foamCoefficients_) {
+            serializer.unpack(it.fm_min, buffer, position);
+            serializer.unpack(it.fm_mob, buffer, position);
+            serializer.unpack(it.fm_surf, buffer, position);
+            serializer.unpack(it.ep_surf, buffer, position);
+            serializer.unpack(it.fm_oil, buffer, position);
+            serializer.unpack(it.fl_oil, buffer, position);
+            serializer.unpack(it.ep_oil, buffer, position);
+            serializer.unpack(it.fm_cap, buffer, position);
+            serializer.unpack(it.ep_cap, buffer, position);
+            serializer.unpack(it.fm_dry, buffer, position);
+            serializer.unpack(it.ep_dry, buffer, position);
+        }
+    }
+
 private:
     static std::vector<Scalar> foamRockDensity_;
     static std::vector<bool> foamAllowDesorption_;

--- a/opm/models/blackoil/blackoilpolymermodules.hh
+++ b/opm/models/blackoil/blackoilpolymermodules.hh
@@ -910,8 +910,115 @@ public:
         return 0.25; // kg/mol
     }
 
+    template<class Serializer>
+    static std::size_t packSize(Serializer& serializer)
+    {
+         std::size_t size = serializer.packSize(plyrockDeadPoreVolume_) +
+                            serializer.packSize(plyrockResidualResistanceFactor_) +
+                            serializer.packSize(plyrockRockDensityFactor_) +
+                            serializer.packSize(plyrockAdsorbtionIndex_) +
+                            serializer.packSize(plyrockMaxAdsorbtion_) +
+                            serializer.packSize(plyadsAdsorbedPolymer_) +
+                            serializer.packSize(plyviscViscosityMultiplierTable_) +
+                            serializer.packSize(plymaxMaxConcentration_) +
+                            serializer.packSize(plymixparToddLongstaff_) +
+                            serializer.packSize(plyshlogShearEffectRefMultiplier_) +
+                            serializer.packSize(plyshlogShearEffectRefLogVelocity_) +
+                            serializer.packSize(shrate_) +
+                            serializer.packSize(hasShrate_) +
+                            serializer.packSize(hasPlyshlog_) +
+                            serializer.packSize(plymwinjTables_) +
+                            serializer.packSize(skprwatTables_);
+        size += serializer.packSize(plyvmhCoefficients_.size());
+        for (const auto& it : plyvmhCoefficients_) {
+            size += serializer.packSize(it.k_mh);
+            size += serializer.packSize(it.a_mh);
+            size += serializer.packSize(it.gamma);
+            size += serializer.packSize(it.kappa);
+        }
+        size += serializer.packSize(skprpolyTables_.size());
+        for (const auto& it : skprpolyTables_) {
+            size += serializer.packSize(it.first);
+            size += serializer.packSize(it.second.refConcentration);
+            size += serializer.packSize(it.second.table_func);
+        }
 
+        return size;
+    }
 
+    template<class Serializer>
+    static void pack(std::vector<char>& buffer, int& position,
+                     Serializer& serializer)
+    {
+        serializer.pack(plyrockDeadPoreVolume_, buffer, position);
+        serializer.pack(plyrockResidualResistanceFactor_, buffer, position);
+        serializer.pack(plyrockRockDensityFactor_, buffer, position);
+        serializer.pack(plyrockAdsorbtionIndex_, buffer, position);
+        serializer.pack(plyrockMaxAdsorbtion_, buffer, position);
+        serializer.pack(plyadsAdsorbedPolymer_, buffer, position);
+        serializer.pack(plyviscViscosityMultiplierTable_, buffer, position);
+        serializer.pack(plymaxMaxConcentration_, buffer, position);
+        serializer.pack(plymixparToddLongstaff_, buffer, position);
+        serializer.pack(plyshlogShearEffectRefMultiplier_, buffer, position);
+        serializer.pack(plyshlogShearEffectRefLogVelocity_, buffer, position);
+        serializer.pack(shrate_, buffer, position);
+        serializer.pack(hasShrate_, buffer, position);
+        serializer.pack(hasPlyshlog_, buffer, position);
+        serializer.pack(plymwinjTables_, buffer, position);
+        serializer.pack(skprwatTables_, buffer, position);
+        serializer.pack(plyvmhCoefficients_.size(), buffer, position);
+        for (const auto& it : plyvmhCoefficients_) {
+            serializer.pack(it.k_mh, buffer, position);
+            serializer.pack(it.a_mh, buffer, position);
+            serializer.pack(it.gamma, buffer, position);
+            serializer.pack(it.kappa, buffer, position);
+        }
+        serializer.pack(skprpolyTables_.size(), buffer, position);
+        for (const auto& it : skprpolyTables_) {
+            serializer.pack(it.first, buffer, position);
+            serializer.pack(it.second.refConcentration, buffer, position);
+            serializer.pack(it.second.table_func, buffer, position);
+        }
+    }
+
+    template<class Serializer>
+    static void unpack(std::vector<char>& buffer, int& position,
+                       Serializer& serializer)
+    {
+        serializer.unpack(plyrockDeadPoreVolume_, buffer, position);
+        serializer.unpack(plyrockResidualResistanceFactor_, buffer, position);
+        serializer.unpack(plyrockRockDensityFactor_, buffer, position);
+        serializer.unpack(plyrockAdsorbtionIndex_, buffer, position);
+        serializer.unpack(plyrockMaxAdsorbtion_, buffer, position);
+        serializer.unpack(plyadsAdsorbedPolymer_, buffer, position);
+        serializer.unpack(plyviscViscosityMultiplierTable_, buffer, position);
+        serializer.unpack(plymaxMaxConcentration_, buffer, position);
+        serializer.unpack(plymixparToddLongstaff_, buffer, position);
+        serializer.unpack(plyshlogShearEffectRefMultiplier_, buffer, position);
+        serializer.unpack(plyshlogShearEffectRefLogVelocity_, buffer, position);
+        serializer.unpack(shrate_, buffer, position);
+        serializer.unpack(hasShrate_, buffer, position);
+        serializer.unpack(hasPlyshlog_, buffer, position);
+        serializer.unpack(plymwinjTables_, buffer, position);
+        serializer.unpack(skprwatTables_, buffer, position);
+        size_t size;
+        serializer.unpack(size, buffer, position);
+        plyvmhCoefficients_.resize(size);
+        for (auto& it : plyvmhCoefficients_) {
+            serializer.unpack(it.k_mh, buffer, position);
+            serializer.unpack(it.a_mh, buffer, position);
+            serializer.unpack(it.gamma, buffer, position);
+            serializer.unpack(it.kappa, buffer, position);
+        }
+        serializer.unpack(size, buffer, position);
+        skprpolyTables_.clear();
+        for (size_t i = 0; i < size; ++i) {
+            int key;
+            serializer.unpack(key, buffer, position);
+            serializer.unpack(skprpolyTables_[key].refConcentration, buffer, position);
+            serializer.unpack(skprpolyTables_[key].table_func, buffer, position);
+        }
+    }
 
 private:
     static std::vector<Scalar> plyrockDeadPoreVolume_;

--- a/opm/models/blackoil/blackoilsolventmodules.hh
+++ b/opm/models/blackoil/blackoilsolventmodules.hh
@@ -787,6 +787,64 @@ public:
         return isMiscible_;
     }
 
+    template<class Serializer>
+    static std::size_t packSize(Serializer& serializer)
+    {
+        return serializer.packSize(solventPvt_) +
+               serializer.packSize(ssfnKrg_) +
+               serializer.packSize(ssfnKrs_) +
+               serializer.packSize(sof2Krn_) +
+               serializer.packSize(misc_) +
+               serializer.packSize(pmisc_) +
+               serializer.packSize(msfnKrsg_) +
+               serializer.packSize(msfnKro_) +
+               serializer.packSize(sorwmis_) +
+               serializer.packSize(sgcwmis_) +
+               serializer.packSize(tlMixParamViscosity_) +
+               serializer.packSize(tlMixParamDensity_) +
+               serializer.packSize(tlPMixTable_) +
+               serializer.packSize(isMiscible_);
+    }
+
+    template<class Serializer>
+    static void pack(std::vector<char>& buffer, int& position,
+                     Serializer& serializer)
+    {
+        serializer.pack(solventPvt_, buffer, position);
+        serializer.pack(ssfnKrg_, buffer, position);
+        serializer.pack(ssfnKrs_, buffer, position);
+        serializer.pack(sof2Krn_, buffer, position);
+        serializer.pack(misc_, buffer, position);
+        serializer.pack(pmisc_, buffer, position);
+        serializer.pack(msfnKrsg_, buffer, position);
+        serializer.pack(msfnKro_, buffer, position);
+        serializer.pack(sorwmis_, buffer, position);
+        serializer.pack(sgcwmis_, buffer, position);
+        serializer.pack(tlMixParamViscosity_, buffer, position);
+        serializer.pack(tlMixParamDensity_, buffer, position);
+        serializer.pack(tlPMixTable_, buffer, position);
+        serializer.pack(isMiscible_, buffer, position);
+    }
+
+    template<class Serializer>
+    static void unpack(std::vector<char>& buffer, int& position,
+                       Serializer& serializer)
+    {
+        serializer.unpack(solventPvt_, buffer, position);
+        serializer.unpack(ssfnKrg_, buffer, position);
+        serializer.unpack(ssfnKrs_, buffer, position);
+        serializer.unpack(sof2Krn_, buffer, position);
+        serializer.unpack(misc_, buffer, position);
+        serializer.unpack(pmisc_, buffer, position);
+        serializer.unpack(msfnKrsg_, buffer, position);
+        serializer.unpack(msfnKro_, buffer, position);
+        serializer.unpack(sorwmis_, buffer, position);
+        serializer.unpack(sgcwmis_, buffer, position);
+        serializer.unpack(tlMixParamViscosity_, buffer, position);
+        serializer.unpack(tlMixParamDensity_, buffer, position);
+        serializer.unpack(tlPMixTable_, buffer, position);
+        serializer.unpack(isMiscible_, buffer, position);
+    }
 
 private:
     static SolventPvt solventPvt_;


### PR DESCRIPTION
Admittedly this is a little motivated by lazyness;

I need acesss to the data members in these singletons so I can serialize for parallelization purposes. Writing the (non-)mutable acessors for all these variables seems like a lot of noise for very little gain.