### PR TITLE
disable building of test if Boost::test is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,5 +300,5 @@ opm_add_test(test_tasklets
 
 opm_add_test(test_mpiutil
              PROCESSORS 4
-             CONDITION ${MPI_FOUND}
+             CONDITION ${MPI_FOUND} AND Boost_UNIT_TEST_FRAMEWORK_FOUND
              DRIVER_ARGS --parallel-program=4)


### PR DESCRIPTION
Downstream of https://github.com/OPM/opm-common/pull/1492