### PR TITLE
Fix compilation issues due to removed Dune::shared_ptr.

### DIFF
--- a/opm/models/io/cubegridvanguard.hh
+++ b/opm/models/io/cubegridvanguard.hh
@@ -72,7 +72,7 @@ class CubeGridVanguard : public BaseVanguard<TypeTag>
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, Grid) Grid;
 
-    typedef Dune::shared_ptr<Grid> GridPointer;
+    typedef std::unique_ptr<Grid> GridPointer;
     typedef typename Grid::ctype CoordScalar;
     enum { dimWorld = Grid::dimensionworld };
     typedef Dune::FieldVector<CoordScalar, dimWorld> GlobalPosition;

--- a/opm/models/io/simplexvanguard.hh
+++ b/opm/models/io/simplexvanguard.hh
@@ -65,7 +65,7 @@ class SimplexGridVanguard
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, Grid) Grid;
 
-    typedef Dune::shared_ptr<Grid> GridPointer;
+    typedef std::unique_ptr<Grid> GridPointer;
     typedef typename Grid::ctype CoordScalar;
     enum { dimWorld = Grid::dimensionworld };
     typedef Dune::FieldVector<CoordScalar, dimWorld> GlobalPosition;


### PR DESCRIPTION
Those methods return a unique_ptr since at least DUNE 2.6.

Probably I am having weired options such that these code paths even get compiled.