### PR TITLE
Properly Scale Solvent Saturation

### DIFF
--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -632,7 +632,7 @@ public:
             Scalar St = Sw + Sg + Ssol;
             assert(St>0.5);
             Sw=Sw/St;
-            Ssol=Ssol;
+            Ssol=Ssol/St;
             if (waterEnabled)
                 (*this)[Indices::waterSaturationIdx]= Sw;
             if (enableSolvent)


### PR DESCRIPTION
Fixes a self-assignment issue.