### PR TITLE
Use correct number of template arguments for fracture problem DUNE>2.7

### DIFF
--- a/tests/problems/fractureproblem.hh
+++ b/tests/problems/fractureproblem.hh
@@ -241,7 +241,7 @@ class FractureProblem : public GetPropType<TypeTag, Properties::BaseProblem>
         bool contains(Dune::GeometryType gt)
         { return gt.dim() == dim - 1; }
     };
-    using FaceMapper = Dune::MultipleCodimMultipleGeomTypeMapper<GridView, FaceLayout>;
+    using FaceMapper = Dune::MultipleCodimMultipleGeomTypeMapper<GridView>;
 
     using FractureMapper = Opm::FractureMapper<TypeTag>;
 


### PR DESCRIPTION
The layout parameter has been deprecated some time ago and now removed
in DUNE > 2.7. This commit fixes its last usage in opm-models makes it
compiler with DUNE master.