### PR TITLE
Disable property macros.

### DIFF
--- a/opm/models/utils/propertysystem.hh
+++ b/opm/models/utils/propertysystem.hh
@@ -256,11 +256,6 @@ void printValues(std::ostream& os = std::cout)
 
 } // end namespace Opm
 
-// remove this after release 2020.10 to disable macros per default
-#ifndef OPM_ENABLE_OLD_PROPERTY_MACROS
-#define OPM_ENABLE_OLD_PROPERTY_MACROS 1
-#endif
-
 // remove this after release 2021.04 to remove macros completely
 #if OPM_ENABLE_OLD_PROPERTY_MACROS
 #include <opm/models/utils/propertysystemmacros.hh>


### PR DESCRIPTION
Still available by manually overriding OPM_ENABLE_OLD_PROPERTY_MACROS, but not by default. This change has been communicated for a long time, as due to happen after the 2020.10 release.

Do not backport to the release.