### PR TITLE
fix boundary face index in parallel

### DIFF
--- a/opm/models/discretization/common/fvbaseboundarycontext.hh
+++ b/opm/models/discretization/common/fvbaseboundarycontext.hh
@@ -83,7 +83,7 @@ public:
 
         ++intersectionIt_;
         // iterate to the next boundary intersection
-        while (intersectionIt_ != iend && !intersectionIt_->boundary()) {
+        while (intersectionIt_ != iend && intersectionIt_->neighbor()) {
             ++intersectionIt_;
         }
     }

--- a/opm/models/discretization/common/fvbaselocalresidual.hh
+++ b/opm/models/discretization/common/fvbaselocalresidual.hh
@@ -426,7 +426,7 @@ protected:
 
         BoundaryContext boundaryCtx(elemCtx);
         // move the iterator to the first boundary
-        if(!boundaryCtx.intersection(0).boundary())
+        if(boundaryCtx.intersection(0).neighbor())
             boundaryCtx.increment();
 
         // evaluate the boundary for all boundary faces of the current context
@@ -434,6 +434,9 @@ protected:
         for (unsigned faceIdx = 0; faceIdx < numBoundaryFaces; ++faceIdx, boundaryCtx.increment()) {
             // add the residual of all vertices of the boundary
             // segment
+            if(!boundaryCtx.intersection(faceIdx).boundary())
+                continue;
+
             evalBoundarySegment_(residual,
                                  boundaryCtx,
                                  faceIdx,


### PR DESCRIPTION
The process boundaries are included in the vector of boundary intersections in the stencil i.e. numBoundaryFaces both includes number of real boundaries and process boundaries. This fix make sure that the iterator and the faceIdx are consistent. 