### PR TITLE
Stop pretending that we support CMake 2.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # Mandatory call to project
 project(opm-models C CXX)
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.10)
 
 # add the current projects cmake module directory to the search
 # path. This is not required anymore once support for federated builds


### PR DESCRIPTION
We actually already require at least CMake 2.8.12 due to the embedded pybind11 (some tests of it are even at 3.0). Anyway as Ubuntu LTS has 3.10.2 I doubt that anything less is tested by us.