### PR TITLE
Remove explicit assignment-operator from class

### DIFF
--- a/opm/models/blackoil/blackoilratevector.hh
+++ b/opm/models/blackoil/blackoilratevector.hh
@@ -190,16 +190,6 @@ public:
             (*this)[i] = value;
         return *this;
     }
-
-    /*!
-     * \brief Assignment operator from another rate vector
-     */
-    BlackOilRateVector& operator=(const BlackOilRateVector& other)
-    {
-        for (unsigned i=0; i < this->size(); ++i)
-            (*this)[i] = other[i];
-        return *this;
-    }
 };
 
 } // namespace Opm


### PR DESCRIPTION
since it already has an assigment operator, the implicit
copy-constructor is deprecated. clang likes to
point this out.