### PR TITLE
Enabling water evaporation into the gas phase

### DIFF
--- a/opm/models/blackoil/blackoilbrinemodules.hh
+++ b/opm/models/blackoil/blackoilbrinemodules.hh
@@ -266,7 +266,7 @@ public:
         if (!enableBrine)
             return;
 
-        static unsigned contiGasEqIdx, contiOilEqIdx;
+        static unsigned contiWaterEqIdx, contiGasEqIdx, contiOilEqIdx;
         if(gasEnabled) { contiGasEqIdx = Indices::conti0EqIdx + Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx); }
         if(oilEnabled) { contiOilEqIdx = Indices::conti0EqIdx + Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx); }
 
@@ -284,7 +284,9 @@ public:
                     *up.fluidState().saltConcentration();
 
             if (enableSaltPrecipitation) {
-                // modify gas and oil flux for mobility change
+                // modify fluxes for mobility change
+                flux[contiBrineEqIdx] *= intQuants.permFactor();
+                flux[contiWaterEqIdx] *= intQuants.permFactor();
                 if(gasEnabled) { flux[contiGasEqIdx] *= intQuants.permFactor(); }
                 if(oilEnabled) { flux[contiOilEqIdx] *= intQuants.permFactor(); }
             }
@@ -296,7 +298,9 @@ public:
                     *decay<Scalar>(up.fluidState().saltConcentration());
 
             if (enableSaltPrecipitation) {
-                // modify gas and oil flux for mobility change
+                // modify fluxes for mobility change
+                flux[contiBrineEqIdx] *= decay<Scalar>(intQuants.permFactor());
+                flux[contiWaterEqIdx] *= decay<Scalar>(intQuants.permFactor()); 
                 if(gasEnabled) { flux[contiGasEqIdx] *= decay<Scalar>(intQuants.permFactor()); }
                 if(oilEnabled) { flux[contiOilEqIdx] *= decay<Scalar>(intQuants.permFactor()); }
             }
@@ -489,10 +493,6 @@ public:
             const auto& permfactTable = BrineModule::permfactTable(elemCtx, dofIdx, timeIdx);
 
             permFactor_ = permfactTable.eval(scalarValue(porosityFactor));
-            if (permFactor_ < 1 ) {
-                // adjust mobility for changing permeability
-                asImp_().mobility_[waterPhaseIdx] *= permFactor_;
-            }
          }
     }
 

--- a/opm/models/blackoil/blackoilbrinemodules.hh
+++ b/opm/models/blackoil/blackoilbrinemodules.hh
@@ -266,12 +266,7 @@ public:
         if (!enableBrine)
             return;
 
-        static unsigned contiWaterEqIdx, contiGasEqIdx, contiOilEqIdx;
-        if(gasEnabled) { contiGasEqIdx = Indices::conti0EqIdx + Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx); }
-        if(oilEnabled) { contiOilEqIdx = Indices::conti0EqIdx + Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx); }
-
         const auto& extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
-        const auto& intQuants = elemCtx.intensiveQuantities(scvfIdx, timeIdx);
 
         const unsigned upIdx = extQuants.upstreamIndex(FluidSystem::waterPhaseIdx);
         const unsigned inIdx = extQuants.interiorIndex();
@@ -282,28 +277,12 @@ public:
                     extQuants.volumeFlux(waterPhaseIdx)
                     *up.fluidState().invB(waterPhaseIdx)
                     *up.fluidState().saltConcentration();
-
-            if (enableSaltPrecipitation) {
-                // modify fluxes for mobility change
-                flux[contiBrineEqIdx] *= intQuants.permFactor();
-                flux[contiWaterEqIdx] *= intQuants.permFactor();
-                if(gasEnabled) { flux[contiGasEqIdx] *= intQuants.permFactor(); }
-                if(oilEnabled) { flux[contiOilEqIdx] *= intQuants.permFactor(); }
-            }
         }
         else {
             flux[contiBrineEqIdx] =
                     extQuants.volumeFlux(waterPhaseIdx)
                     *decay<Scalar>(up.fluidState().invB(waterPhaseIdx))
                     *decay<Scalar>(up.fluidState().saltConcentration());
-
-            if (enableSaltPrecipitation) {
-                // modify fluxes for mobility change
-                flux[contiBrineEqIdx] *= decay<Scalar>(intQuants.permFactor());
-                flux[contiWaterEqIdx] *= decay<Scalar>(intQuants.permFactor()); 
-                if(gasEnabled) { flux[contiGasEqIdx] *= decay<Scalar>(intQuants.permFactor()); }
-                if(oilEnabled) { flux[contiOilEqIdx] *= decay<Scalar>(intQuants.permFactor()); }
-            }
         }
     }
 
@@ -493,7 +472,13 @@ public:
             const auto& permfactTable = BrineModule::permfactTable(elemCtx, dofIdx, timeIdx);
 
             permFactor_ = permfactTable.eval(scalarValue(porosityFactor));
-         }
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                if (!FluidSystem::phaseIsActive(phaseIdx))
+                    continue;
+
+                asImp_().mobility_[phaseIdx] *= permFactor_;
+            }
+        }
     }
 
     const Evaluation& saltConcentration() const

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -266,13 +266,11 @@ public:
                 fluidState_.setRv(0.0);
 
             if (FluidSystem::enableVaporizedWater()) {
-                const Evaluation& RvwSat = FluidSystem::saturatedWaterVaporationFactor(fluidState_,
+                const Evaluation& RvwSat = FluidSystem::saturatedVaporizationFactor(fluidState_,
                                                             gasPhaseIdx,
                                                             pvtRegionIdx);
                 fluidState_.setRvw(RvwSat);
             }
-            else //if (compositionSwitchEnabled)
-                fluidState_.setRvw(0.0);
         }
         else if (priVars.primaryVarsMeaning() == PrimaryVariables::Rvw_po_Sg) {
             // The switching variable is the water-gas ratio Rvw

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -149,7 +149,7 @@ public:
         if (waterEnabled) {
             if (priVars.primaryVarsMeaning() == PrimaryVariables::OnePhase_p) {
                 Sw = 1.0;
-            } else {
+            } else if (priVars.primaryVarsMeaning() != PrimaryVariables::Rvw_po_Sg) {
                 Sw = priVars.makeEvaluation(Indices::waterSaturationIdx, timeIdx);
             }
         }
@@ -236,7 +236,7 @@ public:
                         elemCtx.problem().maxOilSaturation(globalSpaceIdx));
         }
 
-        // take the meaning of the switiching primary variable into account for the gas
+        // take the meaning of the switching primary variable into account for the gas
         // and oil phase compositions
         if (priVars.primaryVarsMeaning() == PrimaryVariables::Sw_po_Sg) {
             // in the threephase case, gas and oil phases are potentially present, i.e.,
@@ -264,6 +264,20 @@ public:
             }
             else if (compositionSwitchEnabled)
                 fluidState_.setRv(0.0);
+
+            if (FluidSystem::enableVaporizedWater()) {
+                const Evaluation& RvwSat = FluidSystem::saturatedWaterVaporationFactor(fluidState_,
+                                                            gasPhaseIdx,
+                                                            pvtRegionIdx);
+                fluidState_.setRvw(RvwSat);
+            }
+            else //if (compositionSwitchEnabled)
+                fluidState_.setRvw(0.0);
+        }
+        else if (priVars.primaryVarsMeaning() == PrimaryVariables::Rvw_po_Sg) {
+            // The switching variable is the water-gas ratio Rvw
+            const auto& Rvw = priVars.makeEvaluation(Indices::waterSaturationIdx, timeIdx);
+            fluidState_.setRvw(Rvw);
         }
         else if (priVars.primaryVarsMeaning() == PrimaryVariables::Sw_po_Rs) {
             // if the switching variable is the mole fraction of the gas component in the

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -488,7 +488,8 @@ public:
                                                                                       T,
                                                                                       pg);
                 setPrimaryVarsMeaning(Rvw_po_Sg);
-                //Sw = 0.0; //check
+                (*this)[Indices::waterSaturationIdx] = RvwSat; //primary variable becomes Rvw 
+
                 return true;
             }
 
@@ -607,9 +608,14 @@ public:
             
             Scalar po = (*this)[Indices::pressureSwitchIdx]; 
             Scalar T = asImp_().temperature_();
+            Scalar Sg = 0.0;
+            if (compositionSwitchEnabled)
+                Sg = (*this)[Indices::compositionSwitchIdx];
+
+            Scalar So = 1.0 - Sg - solventSaturation_();
             Scalar pC[numPhases] = { 0.0 };
             const MaterialLawParams& matParams = problem.materialLawParams(globalDofIdx);
-            computeCapillaryPressures_(pC, So, Sg + solventSaturation_(), Sw, matParams);
+            computeCapillaryPressures_(pC, So, Sg + solventSaturation_(), /*Sw=*/ 0.0, matParams);
             Scalar pg = po + (pC[gasPhaseIdx] - pC[oilPhaseIdx]);
             Scalar RvwSat = FluidSystem::gasPvt().saturatedWaterVaporizationFactor(pvtRegionIdx_,
                                                                                    T,

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -129,7 +129,6 @@ public:
         Sw_po_Rs, // water + oil case
         Sw_pg_Rv, // water + gas case
         Rvw_po_Sg, // gas + oil  case
-        //Rvw_pg_Rv, //only gas  + oil-vapor +water-vapor
 
         OnePhase_p, // onephase case
     };


### PR DESCRIPTION
Main items
1) adding gas-water ratio (Rvw)  to the black-oil equations
2) variable switching Sw<->Rvw ( typically water may disappear due to evaporation)
3) flux correction in case of mobility reduction  due to salt precipitation  (opm/models/blackoil/blackoilbrinemodules.hh)

This PR depends on https://github.com/OPM/opm-material/pull/491
