### PR TITLE
Don't copy primary variables into element context

### DIFF
--- a/opm/models/discretization/common/fvbaseelementcontext.hh
+++ b/opm/models/discretization/common/fvbaseelementcontext.hh
@@ -62,7 +62,7 @@ class FvBaseElementContext
 
     struct DofStore_ {
         IntensiveQuantities intensiveQuantities[timeDiscHistorySize];
-        PrimaryVariables priVars[timeDiscHistorySize];
+        const PrimaryVariables* priVars[timeDiscHistorySize];
         const IntensiveQuantities *thermodynamicHint[timeDiscHistorySize];
     };
     using DofVarsVector = std::vector<DofStore_>;
@@ -452,7 +452,7 @@ public:
     const PrimaryVariables& primaryVars(unsigned dofIdx, unsigned timeIdx) const
     {
         assert(dofIdx < numDof(timeIdx));
-        return dofVars_[dofIdx].priVars[timeIdx];
+        return *dofVars_[dofIdx].priVars[timeIdx];
     }
 
     /*!
@@ -483,7 +483,7 @@ public:
         assert(dofIdx < numDof(/*timeIdx=*/0));
 
         intensiveQuantitiesStashed_ = dofVars_[dofIdx].intensiveQuantities[/*timeIdx=*/0];
-        priVarsStashed_ = dofVars_[dofIdx].priVars[/*timeIdx=*/0];
+        priVarsStashed_ = *dofVars_[dofIdx].priVars[/*timeIdx=*/0];
         stashedDofIdx_ = static_cast<int>(dofIdx);
     }
 
@@ -494,7 +494,7 @@ public:
      */
     void restoreIntensiveQuantities(unsigned dofIdx)
     {
-        dofVars_[dofIdx].priVars[/*timeIdx=*/0] = priVarsStashed_;
+        dofVars_[dofIdx].priVars[/*timeIdx=*/0] = &priVarsStashed_;
         dofVars_[dofIdx].intensiveQuantities[/*timeIdx=*/0] = intensiveQuantitiesStashed_;
         stashedDofIdx_ = -1;
     }
@@ -554,7 +554,7 @@ protected:
         for (unsigned dofIdx = 0; dofIdx < numDof; dofIdx++) {
             unsigned globalIdx = globalSpaceIndex(dofIdx, timeIdx);
             const PrimaryVariables& dofSol = globalSol[globalIdx];
-            dofVars_[dofIdx].priVars[timeIdx] = dofSol;
+            dofVars_[dofIdx].priVars[timeIdx] = &dofSol;
 
             dofVars_[dofIdx].thermodynamicHint[timeIdx] =
                 model().thermodynamicHint(globalIdx, timeIdx);
@@ -580,7 +580,7 @@ protected:
                                    "for the most-recent substep (i.e. time index 0) are available!");
 #endif
 
-        dofVars_[dofIdx].priVars[timeIdx] = priVars;
+        dofVars_[dofIdx].priVars[timeIdx] = &priVars;
         dofVars_[dofIdx].intensiveQuantities[timeIdx].update(/*context=*/asImp_(), dofIdx, timeIdx);
     }
 

--- a/opm/models/discretization/common/fvbaseelementcontext.hh
+++ b/opm/models/discretization/common/fvbaseelementcontext.hh
@@ -449,14 +449,6 @@ public:
      * \param timeIdx The index of the solution vector used by the
      *                time discretization.
      */
-    PrimaryVariables& primaryVars(unsigned dofIdx, unsigned timeIdx)
-    {
-        assert(dofIdx < numDof(timeIdx));
-        return dofVars_[dofIdx].priVars[timeIdx];
-    }
-    /*!
-     * \copydoc primaryVars()
-     */
     const PrimaryVariables& primaryVars(unsigned dofIdx, unsigned timeIdx) const
     {
         assert(dofIdx < numDof(timeIdx));


### PR DESCRIPTION
This seems to yield a consistent speedup of assembly in my tests.