### PR TITLE
[bugfix] Prevent accessing undefined variables for brine without salt precipitation

### DIFF
--- a/opm/models/blackoil/blackoilnewtonmethod.hh
+++ b/opm/models/blackoil/blackoilnewtonmethod.hh
@@ -348,7 +348,9 @@ protected:
                 const double sign = delta >= 0. ? 1. : -1.;
                 delta = sign * std::min(std::abs(delta), maxTempChange_);
             }
-            else if (enableBrine && pvIdx == Indices::saltConcentrationIdx && currentValue.primaryVarsMeaningBrine() == PrimaryVariables::Sp) { 
+            else if (enableBrine && pvIdx == Indices::saltConcentrationIdx &&
+                     enableSaltPrecipitation &&
+                     currentValue.primaryVarsMeaningBrine() == PrimaryVariables::Sp) {
                 const double maxSaltSaturationChange = 0.1;
                 const double sign = delta >= 0. ? 1. : -1.;
                 delta = sign * std::min(std::abs(delta), maxSaltSaturationChange);


### PR DESCRIPTION
It seems like `currentValue.primaryVarsMeaningBrine()` will return an uninitialized variable if `enableSaltPrecipitation` is false. This can lead to undefined behavior especially in a parallel run. Hence we also check whether salt precipitation is is enabled and do nothing otherwise.

This change seems to be in line with the other code.

Closes #689 