### PR TITLE
changed: unify matrixblock.hh with downstream MatrixBlock.hpp

### DIFF
--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -55,7 +55,6 @@
 #include <opm/models/utils/timer.hh>
 #include <opm/models/utils/timerguard.hh>
 #include <opm/models/io/vtkprimaryvarsmodule.hh>
-#include <opm/simulators/linalg/matrixblock.hh>
 
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>


### PR DESCRIPTION
Let's try this again.

The issue was that previously a generic utility function was returning the identity matrix for a failed invert.
I changed this and did not realize something was relying on this rather funky behavior (ie the Norne model).
I have now changed it so the generic utility throws, and then the exceptional behavior is applied locally in the well
code instead.

If you do not like this approach and rather want the old one I can do that, but I really do not think that is the proper way to do it.