### PR TITLE
change default max/min temp in newton clamping

### DIFF
--- a/opm/models/blackoil/blackoilnewtonmethod.hh
+++ b/opm/models/blackoil/blackoilnewtonmethod.hh
@@ -83,13 +83,13 @@ template<class TypeTag>
 struct TemperatureMax<TypeTag, TTag::NewtonMethod>
 {
     using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 400; //Kelvin
+    static constexpr type value = 1e9; //Kelvin
 };
 template<class TypeTag>
 struct TemperatureMin<TypeTag, TTag::NewtonMethod>
 {
     using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 280; //Kelvin
+    static constexpr type value = 0.0; //Kelvin
 };
 } // namespace Opm::Properties
 


### PR DESCRIPTION
This removes the default temperature clamping limits for the blackoil thermal model. 