### PR TITLE
fixed: respect rule-of-three for fvbaseintensivequantities

### DIFF
--- a/opm/models/discretization/common/fvbaseintensivequantities.hh
+++ b/opm/models/discretization/common/fvbaseintensivequantities.hh
@@ -48,10 +48,6 @@ class FvBaseIntensiveQuantities
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
 
 public:
-    // default constructor
-    FvBaseIntensiveQuantities()
-    { }
-
     /*!
      * \brief Register all run-time parameters for the intensive quantities.
      */

--- a/opm/models/discretization/common/fvbaseintensivequantities.hh
+++ b/opm/models/discretization/common/fvbaseintensivequantities.hh
@@ -52,9 +52,6 @@ public:
     FvBaseIntensiveQuantities()
     { }
 
-    // copy constructor
-    FvBaseIntensiveQuantities(const FvBaseIntensiveQuantities& v) = default;
-
     /*!
      * \brief Register all run-time parameters for the intensive quantities.
      */


### PR DESCRIPTION
is no need to explicitly declare the cc here