### PR TITLE
Bug fix on solid salt calculation

### DIFF
--- a/opm/models/blackoil/blackoilbrinemodules.hh
+++ b/opm/models/blackoil/blackoilbrinemodules.hh
@@ -239,6 +239,7 @@ public:
                 double saltDensity = 2170; // Solid salt density kg/m3
                 const LhsEval solidSalt =
                               Toolbox::template decay<LhsEval>(intQuants.porosity())
+                              / (1.0 - Toolbox::template decay<LhsEval>(intQuants.saltSaturation()) + 1.e-8)
                               * saltDensity
                               * Toolbox::template decay<LhsEval>(intQuants.saltSaturation());
 
@@ -459,7 +460,7 @@ public:
 
             const auto& permfactTable = BrineModule::permfactTable(elemCtx, dofIdx, timeIdx);
 
-            permFactor_ = permfactTable.eval(scalarValue(porosityFactor));
+            permFactor_ = permfactTable.eval(porosityFactor);
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 if (!FluidSystem::phaseIsActive(phaseIdx))
                     continue;

--- a/opm/models/blackoil/blackoilnewtonmethod.hh
+++ b/opm/models/blackoil/blackoilnewtonmethod.hh
@@ -391,7 +391,7 @@ protected:
                    nextValue[pvIdx] = std::max(nextValue[pvIdx], 0.0); 
                // keep the salt saturation below upperlimit
                if ((enableSaltPrecipitation && currentValue.primaryVarsMeaningBrine() == PrimaryVariables::Sp))
-                   nextValue[pvIdx] = std::min(nextValue[pvIdx], 0.9); 
+                   nextValue[pvIdx] = std::min(nextValue[pvIdx], 1.0-1.e-8); 
             }
 
             // keep the temperature within given values


### PR DESCRIPTION
@plgbrts  It should use the current porosity before being modified by salt precipitation in `blackoilintensivequantities.hh`, i.e., $\phi/(1-S_p)$?