### PR TITLE
blackoilmicpmodules: put parameters in separate class

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -82,7 +82,8 @@ list (APPEND PUBLIC_HEADER_FILES
              opm/models/blackoil/blackoilenergymodules.hh
              opm/models/blackoil/blackoiltwophaseindices.hh
              opm/models/blackoil/blackoilpolymermodules.hh
-						 opm/models/blackoil/blackoilmicpmodules.hh
+             opm/models/blackoil/blackoilmicpmodules.hh
+             opm/models/blackoil/blackoilmicpparams.hh
              opm/models/blackoil/blackoilboundaryratevector.hh
              opm/models/common/multiphasebaseproperties.hh
              opm/models/common/multiphasebasemodel.hh

--- a/opm/models/blackoil/blackoilmicpmodules.hh
+++ b/opm/models/blackoil/blackoilmicpmodules.hh
@@ -139,7 +139,7 @@ public:
     static void checkCloggingMICP(const Model& model, const Scalar phi, unsigned dofIdx)
     {
         const PrimaryVariables& priVars = model.solution(/*timeIdx=*/1)[dofIdx];
-        if (phi - priVars[biofilmConcentrationIdx] - priVars[calciteConcentrationIdx] < MICPparaToleranceBeforeClogging())
+        if (phi - priVars[biofilmConcentrationIdx] - priVars[calciteConcentrationIdx] < toleranceBeforeClogging())
             throw std::logic_error("Clogging has been (almost) reached in at least one cell\n");
     }
 
@@ -148,41 +148,41 @@ public:
      *
      * The index of specified here must be in range [0, numSatRegions)
      */
-    static void setMICPpara(const Scalar& MICPparaDensityBiofilm,
-                            const Scalar& MICPparaDensityCalcite,
-                            const Scalar& MICPparaDetachmentRate,
-                            const Scalar& MICPparaCriticalPorosity,
-                            const Scalar& MICPparaFittingFactor,
-                            const Scalar& MICPparaHalfVelocityOxygen,
-                            const Scalar& MICPparaHalfVelocityUrea,
-                            const Scalar& MICPparaMaximumGrowthRate,
-                            const Scalar& MICPparaMaximumUreaUtilization,
-                            const Scalar& MICPparaMicrobialAttachmentRate,
-                            const Scalar& MICPparaMicrobialDeathRate,
-                            const Scalar& MICPparaMinimumPermeability,
-                            const Scalar& MICPparaOxygenConsumptionFactor,
-                            const Scalar& MICPparaYieldGrowthCoefficient,
-                            const Scalar& MICPparaMaximumOxygenConcentration,
-                            const Scalar& MICPparaMaximumUreaConcentration,
-                            const Scalar& MICPparaToleranceBeforeClogging)
+    static void setMICPpara(const Scalar& densityBiofilm,
+                            const Scalar& densityCalcite,
+                            const Scalar& detachmentRate,
+                            const Scalar& criticalPorosity,
+                            const Scalar& fittingFactor,
+                            const Scalar& halfVelocityOxygen,
+                            const Scalar& halfVelocityUrea,
+                            const Scalar& maximumGrowthRate,
+                            const Scalar& maximumUreaUtilization,
+                            const Scalar& microbialAttachmentRate,
+                            const Scalar& microbialDeathRate,
+                            const Scalar& minimumPermeability,
+                            const Scalar& oxygenConsumptionFactor,
+                            const Scalar& yieldGrowthCoefficient,
+                            const Scalar& maximumOxygenConcentration,
+                            const Scalar& maximumUreaConcentration,
+                            const Scalar& toleranceBeforeClogging)
     {
-        MICPparaDensityBiofilm_ = MICPparaDensityBiofilm;
-        MICPparaDensityCalcite_ = MICPparaDensityCalcite;
-        MICPparaDetachmentRate_ = MICPparaDetachmentRate;
-        MICPparaCriticalPorosity_ = MICPparaCriticalPorosity;
-        MICPparaFittingFactor_ = MICPparaFittingFactor;
-        MICPparaHalfVelocityOxygen_ = MICPparaHalfVelocityOxygen;
-        MICPparaHalfVelocityUrea_ = MICPparaHalfVelocityUrea;
-        MICPparaMaximumGrowthRate_ = MICPparaMaximumGrowthRate;
-        MICPparaMaximumUreaUtilization_ = MICPparaMaximumUreaUtilization;
-        MICPparaMicrobialAttachmentRate_ = MICPparaMicrobialAttachmentRate;
-        MICPparaMicrobialDeathRate_ = MICPparaMicrobialDeathRate;
-        MICPparaMinimumPermeability_ = MICPparaMinimumPermeability;
-        MICPparaOxygenConsumptionFactor_ = MICPparaOxygenConsumptionFactor;
-        MICPparaYieldGrowthCoefficient_ = MICPparaYieldGrowthCoefficient;
-        MICPparaMaximumOxygenConcentration_ = MICPparaMaximumOxygenConcentration;
-        MICPparaMaximumUreaConcentration_ = MICPparaMaximumUreaConcentration;
-        MICPparaToleranceBeforeClogging_ = MICPparaToleranceBeforeClogging;
+        densityBiofilm_ = densityBiofilm;
+        densityCalcite_ = densityCalcite;
+        detachmentRate_ = detachmentRate;
+        criticalPorosity_ = criticalPorosity;
+        fittingFactor_ = fittingFactor;
+        halfVelocityOxygen_ = halfVelocityOxygen;
+        halfVelocityUrea_ = halfVelocityUrea;
+        maximumGrowthRate_ = maximumGrowthRate;
+        maximumUreaUtilization_ = maximumUreaUtilization;
+        microbialAttachmentRate_ = microbialAttachmentRate;
+        microbialDeathRate_ = microbialDeathRate;
+        minimumPermeability_ = minimumPermeability;
+        oxygenConsumptionFactor_ = oxygenConsumptionFactor;
+        yieldGrowthCoefficient_ = yieldGrowthCoefficient;
+        maximumOxygenConcentration_ = maximumOxygenConcentration;
+        maximumUreaConcentration_ = maximumUreaConcentration;
+        toleranceBeforeClogging_ = toleranceBeforeClogging;
     }
 
     /*!
@@ -315,17 +315,17 @@ public:
         }
 
         // get the model parameters
-        Scalar k_a = MICPparaMicrobialAttachmentRate();
-        Scalar k_d = MICPparaMicrobialDeathRate();
-        Scalar rho_b = MICPparaDensityBiofilm();
-        Scalar rho_c = MICPparaDensityCalcite();
-        Scalar k_str = MICPparaDetachmentRate();
-        Scalar k_o = MICPparaHalfVelocityOxygen();
-        Scalar k_u = MICPparaHalfVelocityUrea() / 10.0;//Dividing by scaling factor 10 (see WellInterface_impl.hpp)
-        Scalar mu = MICPparaMaximumGrowthRate();
-        Scalar mu_u = MICPparaMaximumUreaUtilization() / 10.0;//Dividing by scaling factor 10 (see WellInterface_impl.hpp)
-        Scalar Y_sb = MICPparaYieldGrowthCoefficient();
-        Scalar F = MICPparaOxygenConsumptionFactor();
+        Scalar k_a = microbialAttachmentRate();
+        Scalar k_d = microbialDeathRate();
+        Scalar rho_b = densityBiofilm();
+        Scalar rho_c = densityCalcite();
+        Scalar k_str = detachmentRate();
+        Scalar k_o = halfVelocityOxygen();
+        Scalar k_u = halfVelocityUrea() / 10.0;//Dividing by scaling factor 10 (see WellInterface_impl.hpp)
+        Scalar mu = maximumGrowthRate();
+        Scalar mu_u = maximumUreaUtilization() / 10.0;//Dividing by scaling factor 10 (see WellInterface_impl.hpp)
+        Scalar Y_sb = yieldGrowthCoefficient();
+        Scalar F = oxygenConsumptionFactor();
         Scalar Y_uc = 1.67 * 10; //Multiplying by scaling factor 10 (see WellInterface_impl.hpp)
 
         // compute the processes
@@ -346,89 +346,89 @@ public:
         source[Indices::contiCalciteEqIdx] += (rho_b / rho_c) * intQuants.biofilmConcentration() * Y_uc * mu_u * intQuants.ureaConcentration() / (k_u + intQuants.ureaConcentration());
     }
 
-    static const Scalar MICPparaDensityBiofilm()
+    static const Scalar densityBiofilm()
     {
-        return MICPparaDensityBiofilm_;
+        return densityBiofilm_;
     }
 
-    static const Scalar MICPparaDensityCalcite()
+    static const Scalar densityCalcite()
     {
-        return MICPparaDensityCalcite_;
+        return densityCalcite_;
     }
 
-    static const Scalar MICPparaDetachmentRate()
+    static const Scalar detachmentRate()
     {
-        return MICPparaDetachmentRate_;
+        return detachmentRate_;
     }
 
-    static const Scalar MICPparaCriticalPorosity()
+    static const Scalar criticalPorosity()
     {
-        return MICPparaCriticalPorosity_;
+        return criticalPorosity_;
     }
 
-    static const Scalar MICPparaFittingFactor()
+    static const Scalar fittingFactor()
     {
-        return MICPparaFittingFactor_;
+        return fittingFactor_;
     }
 
-    static const Scalar MICPparaHalfVelocityOxygen()
+    static const Scalar halfVelocityOxygen()
     {
-        return MICPparaHalfVelocityOxygen_;
+        return halfVelocityOxygen_;
     }
 
-    static const Scalar MICPparaHalfVelocityUrea()
+    static const Scalar halfVelocityUrea()
     {
-        return MICPparaHalfVelocityUrea_;
+        return halfVelocityUrea_;
     }
 
-    static const Scalar MICPparaMaximumGrowthRate()
+    static const Scalar maximumGrowthRate()
     {
-        return MICPparaMaximumGrowthRate_;
+        return maximumGrowthRate_;
     }
 
-    static const Scalar MICPparaMaximumOxygenConcentration()
+    static const Scalar maximumOxygenConcentration()
     {
-        return MICPparaMaximumOxygenConcentration_;
+        return maximumOxygenConcentration_;
     }
 
-    static const Scalar MICPparaMaximumUreaConcentration()
+    static const Scalar maximumUreaConcentration()
     {
-        return MICPparaMaximumUreaConcentration_ / 10.0;//Dividing by scaling factor 10 (see WellInterface_impl.hpp);
+        return maximumUreaConcentration_ / 10.0;//Dividing by scaling factor 10 (see WellInterface_impl.hpp);
     }
 
-    static const Scalar MICPparaMaximumUreaUtilization()
+    static const Scalar maximumUreaUtilization()
     {
-        return MICPparaMaximumUreaUtilization_;
+        return maximumUreaUtilization_;
     }
 
-    static const Scalar MICPparaMicrobialAttachmentRate()
+    static const Scalar microbialAttachmentRate()
     {
-        return MICPparaMicrobialAttachmentRate_;
+        return microbialAttachmentRate_;
     }
 
-    static const Scalar MICPparaMicrobialDeathRate()
+    static const Scalar microbialDeathRate()
     {
-        return MICPparaMicrobialDeathRate_;
+        return microbialDeathRate_;
     }
 
-    static const Scalar MICPparaMinimumPermeability()
+    static const Scalar minimumPermeability()
     {
-        return MICPparaMinimumPermeability_;
+        return minimumPermeability_;
     }
 
-    static const Scalar MICPparaOxygenConsumptionFactor()
+    static const Scalar oxygenConsumptionFactor()
     {
-        return MICPparaOxygenConsumptionFactor_;
+        return oxygenConsumptionFactor_;
     }
 
-    static const Scalar MICPparaToleranceBeforeClogging()
+    static const Scalar toleranceBeforeClogging()
     {
-        return MICPparaToleranceBeforeClogging_;
+        return toleranceBeforeClogging_;
     }
 
-    static const Scalar MICPparaYieldGrowthCoefficient()
+    static const Scalar yieldGrowthCoefficient()
     {
-        return MICPparaYieldGrowthCoefficient_;
+        return yieldGrowthCoefficient_;
     }
 
     static const std::vector<Scalar> phi()
@@ -437,94 +437,94 @@ public:
     }
 
 private:
-    static Scalar MICPparaDensityBiofilm_;
-    static Scalar MICPparaDensityCalcite_;
-    static Scalar MICPparaDetachmentRate_;
-    static Scalar MICPparaCriticalPorosity_;
-    static Scalar MICPparaFittingFactor_;
-    static Scalar MICPparaHalfVelocityOxygen_;
-    static Scalar MICPparaHalfVelocityUrea_;
-    static Scalar MICPparaMaximumGrowthRate_;
-    static Scalar MICPparaMaximumUreaUtilization_;
-    static Scalar MICPparaMicrobialAttachmentRate_;
-    static Scalar MICPparaMicrobialDeathRate_;
-    static Scalar MICPparaMinimumPermeability_;
-    static Scalar MICPparaOxygenConsumptionFactor_;
-    static Scalar MICPparaYieldGrowthCoefficient_;
-    static Scalar MICPparaMaximumOxygenConcentration_;
-    static Scalar MICPparaMaximumUreaConcentration_;
-    static Scalar MICPparaToleranceBeforeClogging_;
+    static Scalar densityBiofilm_;
+    static Scalar densityCalcite_;
+    static Scalar detachmentRate_;
+    static Scalar criticalPorosity_;
+    static Scalar fittingFactor_;
+    static Scalar halfVelocityOxygen_;
+    static Scalar halfVelocityUrea_;
+    static Scalar maximumGrowthRate_;
+    static Scalar maximumUreaUtilization_;
+    static Scalar microbialAttachmentRate_;
+    static Scalar microbialDeathRate_;
+    static Scalar minimumPermeability_;
+    static Scalar oxygenConsumptionFactor_;
+    static Scalar yieldGrowthCoefficient_;
+    static Scalar maximumOxygenConcentration_;
+    static Scalar maximumUreaConcentration_;
+    static Scalar toleranceBeforeClogging_;
     static std::vector<Scalar> phi_;
 };
 
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaDensityBiofilm_;
+BlackOilMICPModule<TypeTag, enableMICPV>::densityBiofilm_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaDensityCalcite_;
+BlackOilMICPModule<TypeTag, enableMICPV>::densityCalcite_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaDetachmentRate_;
+BlackOilMICPModule<TypeTag, enableMICPV>::detachmentRate_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaCriticalPorosity_;
+BlackOilMICPModule<TypeTag, enableMICPV>::criticalPorosity_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaFittingFactor_;
+BlackOilMICPModule<TypeTag, enableMICPV>::fittingFactor_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaHalfVelocityOxygen_;
+BlackOilMICPModule<TypeTag, enableMICPV>::halfVelocityOxygen_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaHalfVelocityUrea_;
+BlackOilMICPModule<TypeTag, enableMICPV>::halfVelocityUrea_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaMaximumGrowthRate_;
+BlackOilMICPModule<TypeTag, enableMICPV>::maximumGrowthRate_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaMaximumUreaUtilization_;
+BlackOilMICPModule<TypeTag, enableMICPV>::maximumUreaUtilization_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaMicrobialAttachmentRate_;
+BlackOilMICPModule<TypeTag, enableMICPV>::microbialAttachmentRate_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaMicrobialDeathRate_;
+BlackOilMICPModule<TypeTag, enableMICPV>::microbialDeathRate_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaMinimumPermeability_;
+BlackOilMICPModule<TypeTag, enableMICPV>::minimumPermeability_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaOxygenConsumptionFactor_;
+BlackOilMICPModule<TypeTag, enableMICPV>::oxygenConsumptionFactor_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaYieldGrowthCoefficient_;
+BlackOilMICPModule<TypeTag, enableMICPV>::yieldGrowthCoefficient_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaMaximumOxygenConcentration_;
+BlackOilMICPModule<TypeTag, enableMICPV>::maximumOxygenConcentration_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaMaximumUreaConcentration_;
+BlackOilMICPModule<TypeTag, enableMICPV>::maximumUreaConcentration_;
 
 template <class TypeTag, bool enableMICPV>
 typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::MICPparaToleranceBeforeClogging_;
+BlackOilMICPModule<TypeTag, enableMICPV>::toleranceBeforeClogging_;
 
 template <class TypeTag, bool enableMICPV>
 std::vector<typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar>
@@ -576,9 +576,9 @@ public:
         const auto& intQuants = elemCtx.intensiveQuantities(dofIdx, timeIdx);
         const auto& K = elemCtx.problem().intrinsicPermeability(elemCtx, dofIdx, timeIdx);
         Scalar referencePorosity_ = elemCtx.problem().porosity(elemCtx, dofIdx, timeIdx);
-        Scalar eta = MICPModule::MICPparaFittingFactor();
-        Scalar k_min = MICPModule::MICPparaMinimumPermeability();
-        Scalar phi_crit = MICPModule::MICPparaCriticalPorosity();
+        Scalar eta = MICPModule::fittingFactor();
+        Scalar k_min = MICPModule::minimumPermeability();
+        Scalar phi_crit = MICPModule::criticalPorosity();
 
         microbialConcentration_ = priVars.makeEvaluation(microbialConcentrationIdx, timeIdx, linearizationType);
         oxygenConcentration_ = priVars.makeEvaluation(oxygenConcentrationIdx, timeIdx, linearizationType);

--- a/opm/models/blackoil/blackoilmicpmodules.hh
+++ b/opm/models/blackoil/blackoilmicpmodules.hh
@@ -29,6 +29,8 @@
 #define EWOMS_BLACK_OIL_MICP_MODULE_HH
 
 #include "blackoilproperties.hh"
+
+#include <opm/models/blackoil/blackoilmicpparams.hh>
 #include <opm/models/io/vtkblackoilmicpmodule.hh>
 
 #if HAVE_ECL_INPUT
@@ -125,7 +127,7 @@ public:
                            MICPpara.getMaximumUreaConcentration(),
                            MICPpara.getToleranceBeforeClogging());
         // obtain the porosity for the clamp in the blackoilnewtonmethod
-        phi_ = eclState.fieldProps().get_double("PORO");
+        params_.phi_ = eclState.fieldProps().get_double("PORO");
     }
 #endif
 
@@ -166,23 +168,23 @@ public:
                             const Scalar& maximumUreaConcentration,
                             const Scalar& toleranceBeforeClogging)
     {
-        densityBiofilm_ = densityBiofilm;
-        densityCalcite_ = densityCalcite;
-        detachmentRate_ = detachmentRate;
-        criticalPorosity_ = criticalPorosity;
-        fittingFactor_ = fittingFactor;
-        halfVelocityOxygen_ = halfVelocityOxygen;
-        halfVelocityUrea_ = halfVelocityUrea;
-        maximumGrowthRate_ = maximumGrowthRate;
-        maximumUreaUtilization_ = maximumUreaUtilization;
-        microbialAttachmentRate_ = microbialAttachmentRate;
-        microbialDeathRate_ = microbialDeathRate;
-        minimumPermeability_ = minimumPermeability;
-        oxygenConsumptionFactor_ = oxygenConsumptionFactor;
-        yieldGrowthCoefficient_ = yieldGrowthCoefficient;
-        maximumOxygenConcentration_ = maximumOxygenConcentration;
-        maximumUreaConcentration_ = maximumUreaConcentration;
-        toleranceBeforeClogging_ = toleranceBeforeClogging;
+        params_.densityBiofilm_ = densityBiofilm;
+        params_.densityCalcite_ = densityCalcite;
+        params_.detachmentRate_ = detachmentRate;
+        params_.criticalPorosity_ = criticalPorosity;
+        params_.fittingFactor_ = fittingFactor;
+        params_.halfVelocityOxygen_ = halfVelocityOxygen;
+        params_.halfVelocityUrea_ = halfVelocityUrea;
+        params_.maximumGrowthRate_ = maximumGrowthRate;
+        params_.maximumUreaUtilization_ = maximumUreaUtilization;
+        params_.microbialAttachmentRate_ = microbialAttachmentRate;
+        params_.microbialDeathRate_ = microbialDeathRate;
+        params_.minimumPermeability_ = minimumPermeability;
+        params_.oxygenConsumptionFactor_ = oxygenConsumptionFactor;
+        params_.yieldGrowthCoefficient_ = yieldGrowthCoefficient;
+        params_.maximumOxygenConcentration_ = maximumOxygenConcentration;
+        params_.maximumUreaConcentration_ = maximumUreaConcentration;
+        params_.toleranceBeforeClogging_ = toleranceBeforeClogging;
     }
 
     /*!
@@ -348,188 +350,102 @@ public:
 
     static const Scalar densityBiofilm()
     {
-        return densityBiofilm_;
+        return params_.densityBiofilm_;
     }
 
     static const Scalar densityCalcite()
     {
-        return densityCalcite_;
+        return params_.densityCalcite_;
     }
 
     static const Scalar detachmentRate()
     {
-        return detachmentRate_;
+        return params_.detachmentRate_;
     }
 
     static const Scalar criticalPorosity()
     {
-        return criticalPorosity_;
+        return params_.criticalPorosity_;
     }
 
     static const Scalar fittingFactor()
     {
-        return fittingFactor_;
+        return params_.fittingFactor_;
     }
 
     static const Scalar halfVelocityOxygen()
     {
-        return halfVelocityOxygen_;
+        return params_.halfVelocityOxygen_;
     }
 
     static const Scalar halfVelocityUrea()
     {
-        return halfVelocityUrea_;
+        return params_.halfVelocityUrea_;
     }
 
     static const Scalar maximumGrowthRate()
     {
-        return maximumGrowthRate_;
+        return params_.maximumGrowthRate_;
     }
 
     static const Scalar maximumOxygenConcentration()
     {
-        return maximumOxygenConcentration_;
+        return params_.maximumOxygenConcentration_;
     }
 
     static const Scalar maximumUreaConcentration()
     {
-        return maximumUreaConcentration_ / 10.0;//Dividing by scaling factor 10 (see WellInterface_impl.hpp);
+        return params_.maximumUreaConcentration_ / 10.0;//Dividing by scaling factor 10 (see WellInterface_impl.hpp);
     }
 
     static const Scalar maximumUreaUtilization()
     {
-        return maximumUreaUtilization_;
+        return params_.maximumUreaUtilization_;
     }
 
     static const Scalar microbialAttachmentRate()
     {
-        return microbialAttachmentRate_;
+        return params_.microbialAttachmentRate_;
     }
 
     static const Scalar microbialDeathRate()
     {
-        return microbialDeathRate_;
+        return params_.microbialDeathRate_;
     }
 
     static const Scalar minimumPermeability()
     {
-        return minimumPermeability_;
+        return params_.minimumPermeability_;
     }
 
     static const Scalar oxygenConsumptionFactor()
     {
-        return oxygenConsumptionFactor_;
+        return params_.oxygenConsumptionFactor_;
     }
 
     static const Scalar toleranceBeforeClogging()
     {
-        return toleranceBeforeClogging_;
+        return params_.toleranceBeforeClogging_;
     }
 
     static const Scalar yieldGrowthCoefficient()
     {
-        return yieldGrowthCoefficient_;
+        return params_.yieldGrowthCoefficient_;
     }
 
     static const std::vector<Scalar> phi()
     {
-        return phi_;
+        return params_.phi_;
     }
 
 private:
-    static Scalar densityBiofilm_;
-    static Scalar densityCalcite_;
-    static Scalar detachmentRate_;
-    static Scalar criticalPorosity_;
-    static Scalar fittingFactor_;
-    static Scalar halfVelocityOxygen_;
-    static Scalar halfVelocityUrea_;
-    static Scalar maximumGrowthRate_;
-    static Scalar maximumUreaUtilization_;
-    static Scalar microbialAttachmentRate_;
-    static Scalar microbialDeathRate_;
-    static Scalar minimumPermeability_;
-    static Scalar oxygenConsumptionFactor_;
-    static Scalar yieldGrowthCoefficient_;
-    static Scalar maximumOxygenConcentration_;
-    static Scalar maximumUreaConcentration_;
-    static Scalar toleranceBeforeClogging_;
-    static std::vector<Scalar> phi_;
+    static BlackOilMICPParams<Scalar> params_;
 };
 
 
 template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::densityBiofilm_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::densityCalcite_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::detachmentRate_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::criticalPorosity_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::fittingFactor_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::halfVelocityOxygen_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::halfVelocityUrea_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::maximumGrowthRate_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::maximumUreaUtilization_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::microbialAttachmentRate_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::microbialDeathRate_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::minimumPermeability_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::oxygenConsumptionFactor_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::yieldGrowthCoefficient_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::maximumOxygenConcentration_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::maximumUreaConcentration_;
-
-template <class TypeTag, bool enableMICPV>
-typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar
-BlackOilMICPModule<TypeTag, enableMICPV>::toleranceBeforeClogging_;
-
-template <class TypeTag, bool enableMICPV>
-std::vector<typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar>
-BlackOilMICPModule<TypeTag, enableMICPV>::phi_;
-
+BlackOilMICPParams<typename BlackOilMICPModule<TypeTag, enableMICPV>::Scalar>
+BlackOilMICPModule<TypeTag, enableMICPV>::params_;
 
 /*!
  * \ingroup BlackOil

--- a/opm/models/blackoil/blackoilmicpmodules.hh
+++ b/opm/models/blackoil/blackoilmicpmodules.hh
@@ -30,7 +30,6 @@
 
 #include "blackoilproperties.hh"
 #include <opm/models/io/vtkblackoilmicpmodule.hh>
-#include <opm/models/common/quantitycallbacks.hh>
 
 #if HAVE_ECL_INPUT
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
@@ -39,6 +38,9 @@
 
 #include <dune/common/fvector.hh>
 
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
 #include <string>
 
 namespace Opm {

--- a/opm/models/blackoil/blackoilmicpparams.hh
+++ b/opm/models/blackoil/blackoilmicpparams.hh
@@ -1,0 +1,60 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Contains the parameters required to extend the black-oil model by MICP.
+ */
+#ifndef EWOMS_BLACK_OIL_MICP_PARAMS_HH
+#define EWOMS_BLACK_OIL_MICP_PARAMS_HH
+
+#include <vector>
+
+namespace Opm {
+
+//! \brief Struct holding the parameters for the BlackOilMICPModule class.
+template<class Scalar>
+struct BlackOilMICPParams {
+    Scalar densityBiofilm_;
+    Scalar densityCalcite_;
+    Scalar detachmentRate_;
+    Scalar criticalPorosity_;
+    Scalar fittingFactor_;
+    Scalar halfVelocityOxygen_;
+    Scalar halfVelocityUrea_;
+    Scalar maximumGrowthRate_;
+    Scalar maximumUreaUtilization_;
+    Scalar microbialAttachmentRate_;
+    Scalar microbialDeathRate_;
+    Scalar minimumPermeability_;
+    Scalar oxygenConsumptionFactor_;
+    Scalar yieldGrowthCoefficient_;
+    Scalar maximumOxygenConcentration_;
+    Scalar maximumUreaConcentration_;
+    Scalar toleranceBeforeClogging_;
+    std::vector<Scalar> phi_;
+};
+
+} // namespace Opm
+
+#endif

--- a/opm/models/blackoil/blackoilnewtonmethod.hh
+++ b/opm/models/blackoil/blackoilnewtonmethod.hh
@@ -404,15 +404,15 @@ protected:
             // concentration (the urea concentration has been scaled by 10). For
             // the biofilm and calcite, we set this value equal to the porosity minus the clogging tolerance.
             if (enableMICP && pvIdx == Indices::microbialConcentrationIdx)
-                nextValue[pvIdx] = std::clamp(nextValue[pvIdx], 0.0, MICPModule::MICPparaDensityBiofilm());
+                nextValue[pvIdx] = std::clamp(nextValue[pvIdx], 0.0, MICPModule::densityBiofilm());
             if (enableMICP && pvIdx == Indices::oxygenConcentrationIdx)
-                nextValue[pvIdx] = std::clamp(nextValue[pvIdx], 0.0, MICPModule::MICPparaMaximumOxygenConcentration());
+                nextValue[pvIdx] = std::clamp(nextValue[pvIdx], 0.0, MICPModule::maximumOxygenConcentration());
             if (enableMICP && pvIdx == Indices::ureaConcentrationIdx)
-                nextValue[pvIdx] = std::clamp(nextValue[pvIdx], 0.0, MICPModule::MICPparaMaximumUreaConcentration());
+                nextValue[pvIdx] = std::clamp(nextValue[pvIdx], 0.0, MICPModule::maximumUreaConcentration());
             if (enableMICP && pvIdx == Indices::biofilmConcentrationIdx)
-                nextValue[pvIdx] = std::clamp(nextValue[pvIdx], 0.0, MICPModule::phi()[globalDofIdx] - MICPModule::MICPparaToleranceBeforeClogging());
+                nextValue[pvIdx] = std::clamp(nextValue[pvIdx], 0.0, MICPModule::phi()[globalDofIdx] - MICPModule::toleranceBeforeClogging());
             if (enableMICP && pvIdx == Indices::calciteConcentrationIdx)
-                nextValue[pvIdx] = std::clamp(nextValue[pvIdx], 0.0, MICPModule::phi()[globalDofIdx] - MICPModule::MICPparaToleranceBeforeClogging());
+                nextValue[pvIdx] = std::clamp(nextValue[pvIdx], 0.0, MICPModule::phi()[globalDofIdx] - MICPModule::toleranceBeforeClogging());
         }
 
         // switch the new primary variables to something which is physically meaningful.


### PR DESCRIPTION
limits the amount of static variable declarations

also clean up variable names.
