### PR TITLE
Fixes compilation with DUNE 2.9 and 2.6

### DIFF
--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -1373,8 +1373,13 @@ public:
 
                 // if the grid has potentially changed, we need to re-create the
                 // supporting data structures.
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 8)
+                elementMapper_.update(gridView_);
+                vertexMapper_.update(gridView_);
+#else
                 elementMapper_.update();
                 vertexMapper_.update();
+#endif
                 resetLinearizer();
 
                 // this is a bit hacky because it supposes that Problem::finishInit()

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -300,8 +300,13 @@ public:
      */
     void gridChanged()
     {
-        elementMapper_.update();
-        vertexMapper_.update();
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 8)
+                elementMapper_.update(gridView_);
+                vertexMapper_.update(gridView_);
+#else
+                elementMapper_.update();
+                vertexMapper_.update();
+#endif
 
         if (enableVtkOutput_())
             defaultVtkWriter_->gridChanged();

--- a/opm/models/io/vtkmultiwriter.hh
+++ b/opm/models/io/vtkmultiwriter.hh
@@ -163,8 +163,13 @@ public:
      */
     void gridChanged()
     {
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 8)
+        elementMapper_.update(gridView_);
+        vertexMapper_.update(gridView_);
+#else
         elementMapper_.update();
         vertexMapper_.update();
+#endif
     }
 
     /*!

--- a/opm/models/nonlinear/newtonmethod.hh
+++ b/opm/models/nonlinear/newtonmethod.hh
@@ -155,6 +155,19 @@ struct NewtonMaxIterations<TypeTag, TTag::NewtonMethod> { static constexpr int v
 } // namespace Opm::Properties
 
 namespace Opm {
+namespace detail
+{
+inline auto getMPIHelperCommunicator()
+{
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    return Dune::MPIHelper::getCommunicator();
+#else
+    static Dune::MPIHelper::MPICommunicator comm;
+    return comm;
+#endif
+}
+}
+
 /*!
  * \ingroup Newton
  * \brief The multi-dimensional Newton method.
@@ -192,11 +205,7 @@ public:
         : simulator_(simulator)
         , endIterMsgStream_(std::ostringstream::out)
         , linearSolver_(simulator)
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-        , comm_(Dune::MPIHelper::getCommunicator())
-#else
-        , comm_(Dune::MPIHelper::getCollectiveCommunicator())
-#endif
+        , comm_(detail::getMPIHelperCommunicator())
         , convergenceWriter_(asImp_())
     {
         lastError_ = 1e100;

--- a/opm/models/nonlinear/newtonmethod.hh
+++ b/opm/models/nonlinear/newtonmethod.hh
@@ -181,14 +181,22 @@ class NewtonMethod
     using ConvergenceWriter = GetPropType<TypeTag, Properties::NewtonConvergenceWriter>;
 
     using Communicator = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using CollectiveCommunication = typename Dune::Communication<typename Dune::MPIHelper::MPICommunicator>;
+#else
     using CollectiveCommunication = Dune::CollectiveCommunication<Communicator>;
+#endif
 
 public:
     NewtonMethod(Simulator& simulator)
         : simulator_(simulator)
         , endIterMsgStream_(std::ostringstream::out)
         , linearSolver_(simulator)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
         , comm_(Dune::MPIHelper::getCommunicator())
+#else
+        , comm_(Dune::MPIHelper::getCollectiveCommunicator())
+#endif
         , convergenceWriter_(asImp_())
     {
         lastError_ = 1e100;

--- a/opm/models/utils/simulator.hh
+++ b/opm/models/utils/simulator.hh
@@ -47,9 +47,24 @@
 #include <string>
 #include <memory>
 
-#define EWOMS_CATCH_PARALLEL_EXCEPTIONS_FATAL(code)                      \
+namespace Opm
+{
+namespace detail
+{
+inline auto getMPIHelperCommunication()
+{
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    return Dune::MPIHelper::getCommunication();
+#else
+    return Dune::MPIHelper::getCollectiveCommunication();
+#endif
+}
+} // end namespace detail
+} // end namespace Opm
+
+#define EWOMS_CATCH_PARALLEL_EXCEPTIONS_FATAL(code)                     \
     {                                                                   \
-        const auto& comm = Dune::MPIHelper::getCollectiveCommunication(); \
+        const auto& comm = ::Opm::detail::getMPIHelperCommunication();  \
         bool exceptionThrown = false;                                   \
         try { code; }                                                   \
         catch (const Dune::Exception& e) {                              \

--- a/opm/simulators/linalg/overlappingscalarproduct.hh
+++ b/opm/simulators/linalg/overlappingscalarproduct.hh
@@ -43,8 +43,12 @@ class OverlappingScalarProduct
 {
 public:
     using field_type = typename OverlappingBlockVector::field_type;
-    using CollectiveCommunication = typename Dune::CollectiveCommunication<typename Dune::MPIHelper::MPICommunicator>;
 
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using CollectiveCommunication = typename Dune::Communication<typename Dune::MPIHelper::MPICommunicator>;
+#else
+    using CollectiveCommunication = typename Dune::CollectiveCommunication<typename Dune::MPIHelper::MPICommunicator>;
+#endif
     using real_type = typename Dune::ScalarProduct<OverlappingBlockVector>::real_type;
 
     //! the kind of computations supported by the operator. Either overlapping or non-overlapping
@@ -52,7 +56,12 @@ public:
     { return Dune::SolverCategory::overlapping; }
 
     OverlappingScalarProduct(const Overlap& overlap)
-        : overlap_(overlap), comm_( Dune::MPIHelper::getCollectiveCommunication() )
+        : overlap_(overlap),
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+          comm_( Dune::MPIHelper::getCommunication() )
+#else
+          comm_( Dune::MPIHelper::getCollectiveCommunication() )
+#endif
     {}
 
 #if DUNE_VERSION_NEWER(DUNE_ISTL, 2,7)


### PR DESCRIPTION
Compilation of the tests has broken since month for DUNE 2.6.
Somewhat related to OPM/opm-grid#587, but should also be mergable independently.