### PR TITLE
Register all (not just some) of the vtk parameters unconditionally.

### DIFF
--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -326,9 +326,7 @@ public:
         // register runtime parameters of the VTK output modules
         VtkBlackOilModule<TypeTag>::registerParameters();
         VtkCompositionModule<TypeTag>::registerParameters();
-
-        if constexpr (enableDiffusion)
-            VtkDiffusionModule<TypeTag>::registerParameters();
+        VtkDiffusionModule<TypeTag>::registerParameters();
     }
 
     /*!


### PR DESCRIPTION
No reason to treat the diffusion parameters differently. This caused the FlowEarlyBird (TypeTag) set of parameters to differ from the one used for Flow blackoil, since that (using TpfaLinearizer) does not activate diffusion.

Closes OPM/opm-common#3168