### PR TITLE
Put properties of Newton method into separate header for reuse.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -185,7 +185,7 @@ list (APPEND PUBLIC_HEADER_FILES
              opm/models/io/vtkblackoilenergymodule.hh
              opm/models/io/baseoutputmodule.hh
              opm/models/io/vtkblackoilpolymermodule.hh
-						 opm/models/io/vtkblackoilmicpmodule.hh
+             opm/models/io/vtkblackoilmicpmodule.hh
              opm/models/ncp/ncpmodel.hh
              opm/models/ncp/ncpindices.hh
              opm/models/ncp/ncpextensivequantities.hh
@@ -198,6 +198,7 @@ list (APPEND PUBLIC_HEADER_FILES
              opm/models/ncp/ncpboundaryratevector.hh
              opm/models/nonlinear/nullconvergencewriter.hh
              opm/models/nonlinear/newtonmethod.hh
+             opm/models/nonlinear/newtonmethodproperties.hh
              opm/models/parallel/mpiutil.hh
              opm/models/parallel/tasklets.hh
              opm/models/parallel/threadmanager.hh

--- a/opm/models/nonlinear/newtonmethod.hh
+++ b/opm/models/nonlinear/newtonmethod.hh
@@ -29,8 +29,7 @@
 
 #include "nullconvergencewriter.hh"
 
-#include <opm/models/utils/propertysystem.hh>
-#include <opm/models/utils/parametersystem.hh>
+#include "newtonmethodproperties.hh"
 #include <opm/models/utils/timer.hh>
 #include <opm/models/utils/timerguard.hh>
 #include <opm/simulators/linalg/linalgproperties.hh>
@@ -68,61 +67,6 @@ namespace TTag {
 struct NewtonMethod {};
 
 } // namespace TTag
-
-//! Specifies the type of the actual Newton method
-template<class TypeTag, class MyTypeTag>
-struct NewtonMethod { using type = UndefinedProperty; };
-
-//! The class which linearizes the non-linear system of equations
-template<class TypeTag, class MyTypeTag>
-struct Linearizer { using type = UndefinedProperty; };
-
-//! Specifies whether the Newton method should print messages or not
-template<class TypeTag, class MyTypeTag>
-struct NewtonVerbose { using type = UndefinedProperty; };
-
-//! Specifies the type of the class which writes out the Newton convergence
-template<class TypeTag, class MyTypeTag>
-struct NewtonConvergenceWriter { using type = UndefinedProperty; };
-
-//! Specifies whether the convergence rate and the global residual
-//! gets written out to disk for every Newton iteration
-template<class TypeTag, class MyTypeTag>
-struct NewtonWriteConvergence { using type = UndefinedProperty; };
-
-//! Specifies whether the convergence rate and the global residual
-//! gets written out to disk for every Newton iteration
-template<class TypeTag, class MyTypeTag>
-struct ConvergenceWriter { using type = UndefinedProperty; };
-
-/*!
- * \brief The value for the error below which convergence is declared
- *
- * This value can (and for the porous media models will) be changed to account for grid
- * scaling and other effects.
- */
-template<class TypeTag, class MyTypeTag>
-struct NewtonTolerance { using type = UndefinedProperty; };
-
-//! The maximum error which may occur in a simulation before the
-//! Newton method for the time step is aborted
-template<class TypeTag, class MyTypeTag>
-struct NewtonMaxError { using type = UndefinedProperty; };
-
-/*!
- * \brief The number of iterations at which the Newton method
- *        should aim at.
- *
- * This is used to control the time-step size. The heuristic used
- * is to scale the last time-step size by the deviation of the
- * number of iterations used from the target steps.
- */
-template<class TypeTag, class MyTypeTag>
-struct NewtonTargetIterations { using type = UndefinedProperty; };
-
-//! Number of maximum iterations for the Newton method.
-template<class TypeTag, class MyTypeTag>
-struct NewtonMaxIterations { using type = UndefinedProperty; };
 
 // set default values for the properties
 template<class TypeTag>

--- a/opm/models/nonlinear/newtonmethod.hh
+++ b/opm/models/nonlinear/newtonmethod.hh
@@ -94,7 +94,7 @@ struct NewtonMaxError<TypeTag, TTag::NewtonMethod>
 template<class TypeTag>
 struct NewtonTargetIterations<TypeTag, TTag::NewtonMethod> { static constexpr int value = 10; };
 template<class TypeTag>
-struct NewtonMaxIterations<TypeTag, TTag::NewtonMethod> { static constexpr int value = 18; };
+struct NewtonMaxIterations<TypeTag, TTag::NewtonMethod> { static constexpr int value = 20; };
 
 } // namespace Opm::Properties
 

--- a/opm/models/nonlinear/newtonmethodproperties.hh
+++ b/opm/models/nonlinear/newtonmethodproperties.hh
@@ -1,0 +1,87 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef EWOMS_NEWTON_METHOD_POPERTIES_HH
+#define EWOMS_NEWTON_METHOD_POPERTIES_HH
+
+#include <opm/models/utils/propertysystem.hh>
+#include <opm/models/utils/parametersystem.hh>
+namespace Opm::Properties {
+
+//! Specifies the type of the actual Newton method
+template<class TypeTag, class MyTypeTag>
+struct NewtonMethod { using type = UndefinedProperty; };
+
+//! The class which linearizes the non-linear system of equations
+template<class TypeTag, class MyTypeTag>
+struct Linearizer { using type = UndefinedProperty; };
+
+//! Specifies whether the Newton method should print messages or not
+template<class TypeTag, class MyTypeTag>
+struct NewtonVerbose { using type = UndefinedProperty; };
+
+//! Specifies the type of the class which writes out the Newton convergence
+template<class TypeTag, class MyTypeTag>
+struct NewtonConvergenceWriter { using type = UndefinedProperty; };
+
+//! Specifies whether the convergence rate and the global residual
+//! gets written out to disk for every Newton iteration
+template<class TypeTag, class MyTypeTag>
+struct NewtonWriteConvergence { using type = UndefinedProperty; };
+
+//! Specifies whether the convergence rate and the global residual
+//! gets written out to disk for every Newton iteration
+template<class TypeTag, class MyTypeTag>
+struct ConvergenceWriter { using type = UndefinedProperty; };
+
+/*!
+ * \brief The value for the error below which convergence is declared
+ *
+ * This value can (and for the porous media models will) be changed to account for grid
+ * scaling and other effects.
+ */
+template<class TypeTag, class MyTypeTag>
+struct NewtonTolerance { using type = UndefinedProperty; };
+
+//! The maximum error which may occur in a simulation before the
+//! Newton method for the time step is aborted
+template<class TypeTag, class MyTypeTag>
+struct NewtonMaxError { using type = UndefinedProperty; };
+
+/*!
+ * \brief The number of iterations at which the Newton method
+ *        should aim at.
+ *
+ * This is used to control the time-step size. The heuristic used
+ * is to scale the last time-step size by the deviation of the
+ * number of iterations used from the target steps.
+ */
+template<class TypeTag, class MyTypeTag>
+struct NewtonTargetIterations { using type = UndefinedProperty; };
+
+//! Number of maximum iterations for the Newton method.
+template<class TypeTag, class MyTypeTag>
+struct NewtonMaxIterations { using type = UndefinedProperty; };
+
+} // end namespace  Opm::Properties
+
+#endif


### PR DESCRIPTION
Now they can be reused in opm-simulators without any hassle.
There will be a downstream change.