### PR TITLE
fix bug in boundary conditions for energy by adding the scaling factor

### DIFF
--- a/opm/models/blackoil/blackoilboundaryratevector.hh
+++ b/opm/models/blackoil/blackoilboundaryratevector.hh
@@ -161,7 +161,7 @@ public:
                 }
 
                 Evaluation enthalpyRate = density*extQuants.volumeFlux(phaseIdx)*specificEnthalpy;
-                EnergyModule::addToEnthalpyRate(*this, enthalpyRate);
+                EnergyModule::addToEnthalpyRate(*this, enthalpyRate*getPropValue<TypeTag, Properties::BlackOilEnergyScalingFactor>());
             }
         }
 
@@ -189,7 +189,7 @@ public:
 
         // heat conduction
         if constexpr (enableEnergy)
-            EnergyModule::addToEnthalpyRate(*this, extQuants.energyFlux());
+            EnergyModule::addToEnthalpyRate(*this, extQuants.energyFlux()*getPropValue<TypeTag, Properties::BlackOilEnergyScalingFactor>());
 
 #ifndef NDEBUG
         for (unsigned i = 0; i < numEq; ++i) {


### PR DESCRIPTION
Since this is a bug fix I add a release flag. 

Case with free boundary on the right and an injector injecting 10 C on the left. 

Current master
![image](https://user-images.githubusercontent.com/3223024/197209276-bf553021-620c-4cce-acc8-00e1e1945cdb.png)

With PR
![image](https://user-images.githubusercontent.com/3223024/197209236-b3dc8100-c215-40f0-8279-5cd9b17c7039.png)
