### PR TITLE
Add interface for updating stored parameters in linearizers.

### DIFF
--- a/opm/models/discretization/common/fvbaselinearizer.hh
+++ b/opm/models/discretization/common/fvbaselinearizer.hh
@@ -282,6 +282,11 @@ public:
         return linearizationType_;
     };
 
+    void updateDiscretizationParameters()
+    {
+        // This linearizer stores no such parameters.
+    }
+
     /*!
      * \brief Returns the map of constraint degrees of freedom.
      *

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -265,6 +265,11 @@ public:
         return linearizationType_;
     };
 
+    void updateDiscretizationParameters()
+    {
+        updateStoredTransmissibilities();
+    }
+
     /*!
      * \brief Returns the map of constraint degrees of freedom.
      *
@@ -497,6 +502,22 @@ private:
             jacobian_->addToBlock(globI, globI, bMat);
         }
     }
+
+    void updateStoredTransmissibilities()
+    {
+        unsigned numCells = model_().numTotalDof();
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+        for (unsigned globI = 0; globI < numCells; globI++) {
+            auto nbInfos = neighborInfo_[globI]; // nbInfos will be a SparseTable<...>::mutable_iterator_range.
+            for (auto& nbInfo : nbInfos) {
+                unsigned globJ = nbInfo.neighbor;
+                nbInfo.trans = problem_().transmissibility(globI, globJ);
+            }
+        }
+    }
+
 
     Simulator *simulatorPtr_;
 


### PR DESCRIPTION
Implement for the TpfaLinearizer to update transmissibilities. The regular linearizer stores no such parameters and has an empty implementations.

Necessary to handle correctly cases with e.g. MULTFLT in the SCHEDULE section. Downstream PR adds call to this method.