### PR TITLE
Extend support for KRNUM to solvent module

### DIFF
--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -39,11 +39,11 @@
 #include "blackoilmicpmodules.hh"
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/common/Valgrind.hpp>
+#include <opm/models/common/directionalmobility.hh>
 
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/utility/CopyablePtr.hpp>
-
 #include <dune/common/fmatrix.hh>
 
 #include <cstring>
@@ -421,22 +421,15 @@ public:
         }
         paramCache.updateAll(fluidState_);
 
+        auto mobilities = getMobilityVector();
         // compute the phase densities and transform the phase permeabilities into mobilities
-        int nmobilities = 1;
-        std::vector<std::array<Evaluation,numPhases>*> mobilities = {&mobility_};
-        if (dirMob_) {
-            for (int i=0; i<3; i++) {
-                nmobilities += 1;
-                mobilities.push_back(&(dirMob_->getArray(i)));
-            }
-        }
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             if (!FluidSystem::phaseIsActive(phaseIdx))
                 continue;
             const auto& b = FluidSystem::inverseFormationVolumeFactor(fluidState_, phaseIdx, pvtRegionIdx);
             fluidState_.setInvB(phaseIdx, b);
             const auto& mu = FluidSystem::viscosity(fluidState_, paramCache, phaseIdx);
-            for (int i = 0; i<nmobilities; i++) {
+            for (std::size_t i = 0; i<mobilities.size(); i++) {
                 if (enableExtbo && phaseIdx == oilPhaseIdx) {
                     (*mobilities[i])[phaseIdx] /= asImp_().oilViscosity();
                 }
@@ -563,6 +556,20 @@ public:
      */
     const FluidState& fluidState() const
     { return fluidState_; }
+        
+    /*!
+     * Returns a vector of pointer to the mobilities. This includes the directional mobilities if they have
+     * been enabled.
+     */
+    std::vector<std::array<Evaluation,numPhases>*> getMobilityVector() {
+        std::vector<std::array<Evaluation,numPhases>*> mobilities = {&mobility_};
+        if (dirMob_) {
+            for (int i=0; i<3; i++) {
+                mobilities.push_back(&(dirMob_->getArray(i)));
+            }
+        }
+        return mobilities;
+    }
 
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::mobility
@@ -658,8 +665,12 @@ private:
 
     // Instead of writing a custom copy constructor and a custom assignment operator just to handle
     // the dirMob_ unique ptr member variable when copying BlackOilIntensiveQuantites (see for example
-    // updateIntensitiveQuantities_() in fvbaseelementcontext.hh for a copy example) we write the below
-    // custom wrapper class CopyablePtr which wraps the unique ptr and makes it copyable.
+    // updateIntensitiveQuantities_() in fvbaseelementcontext.hh for a copy example) we use the
+    // wrapper class
+    //
+    //   DirectionalMobilityPtr (aka Opm::Utility::CopyablePtr<DirectionalMobility<TypeTag, Evaluation>>)
+    //
+    // which wraps the unique ptr and makes it copyable.
     //
     // The advantage of this approach is that we avoid having to call all the base class copy constructors and
     // assignment operators explicitly (which is needed when writing the custom copy constructor and assignment


### PR DESCRIPTION
Implements support for directional relative permeabilities for the solvent module. This is an extension of the work in https://github.com/OPM/opm-simulators/pull/4048. A test case [SOLVENT_KRNUMXY.DATA](https://github.com/OPM/opm-tests/pull/844) has been added to opm-test in order to test this extension. A sample comparison with [SPE1CASE2_SOLVENT.DATA](https://github.com/OPM/opm-tests/blob/master/spe1_solvent/SPE1CASE2_SOLVENT.DATA) (which does not use directional relperms) for FGOR is shown below:

![Gas_Oil_Ratio3](https://user-images.githubusercontent.com/6708379/199466188-6070d958-b0c1-4730-8b44-168f1c77937f.png)
