### PR TITLE
Refactor primary variable meaning

### DIFF
--- a/opm/models/blackoil/blackoilbrinemodules.hh
+++ b/opm/models/blackoil/blackoilbrinemodules.hh
@@ -428,7 +428,7 @@ public:
             const auto& saltdenTable = BrineModule::saltdenTable(elemCtx, dofIdx, timeIdx);
             saltDensity_ = saltdenTable;
 
-            if (priVars.primaryVarsMeaningBrine() == PrimaryVariables::Sp) {
+            if (priVars.primaryVarsMeaningBrine() == PrimaryVariables::PrimaryVarsMeaningBrine::Sp) {
                 saltSaturation_ = priVars.makeEvaluation(saltConcentrationIdx, timeIdx);
                 fs.setSaltConcentration(saltSolubility_);
             }

--- a/opm/models/blackoil/blackoilbrinemodules.hh
+++ b/opm/models/blackoil/blackoilbrinemodules.hh
@@ -428,7 +428,7 @@ public:
             const auto& saltdenTable = BrineModule::saltdenTable(elemCtx, dofIdx, timeIdx);
             saltDensity_ = saltdenTable;
 
-            if (priVars.primaryVarsMeaningBrine() == PrimaryVariables::PrimaryVarsMeaningBrine::Sp) {
+            if (priVars.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp) {
                 saltSaturation_ = priVars.makeEvaluation(saltConcentrationIdx, timeIdx);
                 fs.setSaltConcentration(saltSolubility_);
             }

--- a/opm/models/blackoil/blackoilextbomodules.hh
+++ b/opm/models/blackoil/blackoilextbomodules.hh
@@ -619,17 +619,14 @@ public:
 
         Evaluation pbub = fs.pressure(oilPhaseIdx);
 
-        if (priVars.primaryVarsMeaning() == PrimaryVariables::Sw_po_Sg) {
+        if (priVars.primaryVarsMeaningWater() == PrimaryVariables::Sw) {
            static const Scalar thresholdWaterFilledCell = 1.0 - 1e-6;
-           Scalar Sw = 0.0;
-           if (Indices::waterEnabled)
-              Sw = priVars.makeEvaluation(Indices::waterSaturationIdx, timeIdx).value();
-
-           if (Sw >= thresholdWaterFilledCell)
+           Scalar sw = priVars.makeEvaluation(Indices::waterSaturationIdx, timeIdx).value();
+           if (sw >= thresholdWaterFilledCell)
               rs_ = 0.0;  // water only, zero rs_ ...
         }
 
-        if (priVars.primaryVarsMeaning() == PrimaryVariables::Sw_po_Rs) {
+        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::Rs) {
            rs_ = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
            const Evaluation zLim = ExtboModule::zLim(pvtRegionIdx);
            if (zFraction_ > zLim) {
@@ -642,7 +639,7 @@ public:
            xVolume_ = ExtboModule::xVolume(pvtRegionIdx, pbub, zFraction_);
         }
 
-        if (priVars.primaryVarsMeaning() == PrimaryVariables::Sw_pg_Rv) {
+        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::Rv) {
            rv_ = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
            Evaluation rvsat = ExtboModule::rv(pvtRegionIdx, pbub, zFraction_);
            bg_ = ExtboModule::bg(pvtRegionIdx, pbub, zFraction_) + ExtboModule::gasCmp(pvtRegionIdx, zFraction_)*(rv_-rvsat);

--- a/opm/models/blackoil/blackoilextbomodules.hh
+++ b/opm/models/blackoil/blackoilextbomodules.hh
@@ -619,14 +619,14 @@ public:
 
         Evaluation pbub = fs.pressure(oilPhaseIdx);
 
-        if (priVars.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Sw) {
+        if (priVars.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw) {
            static const Scalar thresholdWaterFilledCell = 1.0 - 1e-6;
            Scalar sw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx).value();
            if (sw >= thresholdWaterFilledCell)
               rs_ = 0.0;  // water only, zero rs_ ...
         }
 
-        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::Rs) {
+        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Rs) {
            rs_ = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
            const Evaluation zLim = ExtboModule::zLim(pvtRegionIdx);
            if (zFraction_ > zLim) {
@@ -639,7 +639,7 @@ public:
            xVolume_ = ExtboModule::xVolume(pvtRegionIdx, pbub, zFraction_);
         }
 
-        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Rv) {
+        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Rv) {
            rv_ = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
            Evaluation rvsat = ExtboModule::rv(pvtRegionIdx, pbub, zFraction_);
            bg_ = ExtboModule::bg(pvtRegionIdx, pbub, zFraction_) + ExtboModule::gasCmp(pvtRegionIdx, zFraction_)*(rv_-rvsat);

--- a/opm/models/blackoil/blackoilextbomodules.hh
+++ b/opm/models/blackoil/blackoilextbomodules.hh
@@ -621,7 +621,7 @@ public:
 
         if (priVars.primaryVarsMeaningWater() == PrimaryVariables::Sw) {
            static const Scalar thresholdWaterFilledCell = 1.0 - 1e-6;
-           Scalar sw = priVars.makeEvaluation(Indices::waterSaturationIdx, timeIdx).value();
+           Scalar sw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx).value();
            if (sw >= thresholdWaterFilledCell)
               rs_ = 0.0;  // water only, zero rs_ ...
         }

--- a/opm/models/blackoil/blackoilextbomodules.hh
+++ b/opm/models/blackoil/blackoilextbomodules.hh
@@ -619,7 +619,7 @@ public:
 
         Evaluation pbub = fs.pressure(oilPhaseIdx);
 
-        if (priVars.primaryVarsMeaningWater() == PrimaryVariables::Sw) {
+        if (priVars.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Sw) {
            static const Scalar thresholdWaterFilledCell = 1.0 - 1e-6;
            Scalar sw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx).value();
            if (sw >= thresholdWaterFilledCell)
@@ -639,7 +639,7 @@ public:
            xVolume_ = ExtboModule::xVolume(pvtRegionIdx, pbub, zFraction_);
         }
 
-        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::Rv) {
+        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Rv) {
            rv_ = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
            Evaluation rvsat = ExtboModule::rv(pvtRegionIdx, pbub, zFraction_);
            bg_ = ExtboModule::bg(pvtRegionIdx, pbub, zFraction_) + ExtboModule::gasCmp(pvtRegionIdx, zFraction_)*(rv_-rvsat);

--- a/opm/models/blackoil/blackoilindices.hh
+++ b/opm/models/blackoil/blackoilindices.hh
@@ -96,10 +96,20 @@ struct BlackOilIndices
     // Primary variable indices
     ////////
 
-    //! The index of the water saturation
+    /*!
+     * \brief Index of the switching variable which determines the composistion of the water phase
+     *
+     * Depending on the phases present, this variable is either interpreted as
+     * water saturation or vapporized water in gas phase
+     */
     static const int waterSaturationIdx = PVOffset + 0;
 
-    //! Index of the oil pressure in a vector of primary variables
+    /*!
+     * \brief Index of the switching variable which determines the pressure
+     *
+     * Depending on the phases present, this variable is either interpreted as the
+     * pressure of the oil phase, gas phase (if no oil) or water phase (if only water)
+     */
     static const int pressureSwitchIdx = PVOffset + 1;
 
     /*!

--- a/opm/models/blackoil/blackoilindices.hh
+++ b/opm/models/blackoil/blackoilindices.hh
@@ -102,7 +102,7 @@ struct BlackOilIndices
      * Depending on the phases present, this variable is either interpreted as
      * water saturation or vapporized water in gas phase
      */
-    static const int waterSaturationIdx = PVOffset + 0;
+    static const int waterSwitchIdx = PVOffset + 0;
 
     /*!
      * \brief Index of the switching variable which determines the pressure

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -184,20 +184,20 @@ public:
         // extract the water and the gas saturations for convenience
         Evaluation Sw = 0.0;
         if constexpr (waterEnabled) {
-            if (priVars.primaryVarsMeaningWater() == PrimaryVariables::Sw) {
+            if (priVars.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Sw) {
                 Sw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
-            } else if (priVars.primaryVarsMeaningWater() == PrimaryVariables::W_disabled){
+            } else if (priVars.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Disabled){
                 // water is enabled but is not a primary variable i.e. one phase case
                 Sw = 1.0;
             }
         }
         Evaluation Sg = 0.0;
         if constexpr (gasEnabled) {
-            if (priVars.primaryVarsMeaningGas() == PrimaryVariables::Sg) {
+            if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Sg) {
                 Sg = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
-            } else if (priVars.primaryVarsMeaningGas() == PrimaryVariables::Rv) {
+            } else if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Rv) {
                 Sg = 1.0 - Sw;
-            } else if (priVars.primaryVarsMeaningGas() == PrimaryVariables::G_disabled) {
+            } else if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Disabled) {
                 if constexpr (waterEnabled) {
                     Sg = 1.0 - Sw; // two phase water + gas
                 } else {
@@ -233,7 +233,7 @@ public:
         problem.updateRelperms(mobility_, dirMob_, fluidState_, globalSpaceIdx);
 
         // oil is the reference phase for pressure
-        if (priVars.primaryVarsMeaningPressure() == PrimaryVariables::Pg) {
+        if (priVars.primaryVarsMeaningPressure() == PrimaryVariables::PrimaryVarsMeaningPressure::Pg) {
             const Evaluation& pg = priVars.makeEvaluation(Indices::pressureSwitchIdx, timeIdx);
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
                 if (FluidSystem::phaseIsActive(phaseIdx))
@@ -265,7 +265,7 @@ public:
 
         // take the meaning of the switching primary variable into account for the gas
         // and oil phase compositions
-        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::Rs) {
+        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Rs) {
             const auto& Rs = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
             fluidState_.setRs(Rs);
         } else {
@@ -281,7 +281,7 @@ public:
                 fluidState_.setRs(0.0);
         }
 
-        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::Rv) {
+        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Rv) {
             const auto& Rv = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
             fluidState_.setRv(Rv);
         } else {
@@ -297,7 +297,7 @@ public:
                 fluidState_.setRv(0.0);
         }
 
-        if (priVars.primaryVarsMeaningWater() == PrimaryVariables::Rvw) {
+        if (priVars.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Rvw) {
             const auto& Rvw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
             fluidState_.setRvw(Rvw);
         } else {
@@ -414,7 +414,7 @@ public:
         }
 
         // deal with salt-precipitation
-        if (enableSaltPrecipitation && priVars.primaryVarsMeaningBrine() == PrimaryVariables::Sp) {
+        if (enableSaltPrecipitation && priVars.primaryVarsMeaningBrine() == PrimaryVariables::PrimaryVarsMeaningBrine::Sp) {
             Evaluation Sp = priVars.makeEvaluation(Indices::saltConcentrationIdx, timeIdx);
             porosity_ *= (1.0 - Sp);
         }

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -185,7 +185,7 @@ public:
         Evaluation Sw = 0.0;
         if constexpr (waterEnabled) {
             if (priVars.primaryVarsMeaningWater() == PrimaryVariables::Sw) {
-                Sw = priVars.makeEvaluation(Indices::waterSaturationIdx, timeIdx);
+                Sw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
             } else if (priVars.primaryVarsMeaningWater() == PrimaryVariables::W_disabled){
                 // water is enabled but is not a primary variable i.e. one phase case
                 Sw = 1.0;
@@ -298,7 +298,7 @@ public:
         }
 
         if (priVars.primaryVarsMeaningWater() == PrimaryVariables::Rvw) {
-            const auto& Rvw = priVars.makeEvaluation(Indices::waterSaturationIdx, timeIdx);
+            const auto& Rvw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
             fluidState_.setRvw(Rvw);
         } else {
             if (FluidSystem::enableVaporizedWater()) { // Add Sg > 0? i.e. if only water set rv = 0)

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -184,20 +184,20 @@ public:
         // extract the water and the gas saturations for convenience
         Evaluation Sw = 0.0;
         if constexpr (waterEnabled) {
-            if (priVars.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Sw) {
+            if (priVars.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw) {
                 Sw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
-            } else if (priVars.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Disabled){
+            } else if (priVars.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Disabled){
                 // water is enabled but is not a primary variable i.e. one phase case
                 Sw = 1.0;
             }
         }
         Evaluation Sg = 0.0;
         if constexpr (gasEnabled) {
-            if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Sg) {
+            if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg) {
                 Sg = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
-            } else if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Rv) {
+            } else if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Rv) {
                 Sg = 1.0 - Sw;
-            } else if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Disabled) {
+            } else if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Disabled) {
                 if constexpr (waterEnabled) {
                     Sg = 1.0 - Sw; // two phase water + gas
                 } else {
@@ -233,7 +233,7 @@ public:
         problem.updateRelperms(mobility_, dirMob_, fluidState_, globalSpaceIdx);
 
         // oil is the reference phase for pressure
-        if (priVars.primaryVarsMeaningPressure() == PrimaryVariables::PrimaryVarsMeaningPressure::Pg) {
+        if (priVars.primaryVarsMeaningPressure() == PrimaryVariables::PressureMeaning::Pg) {
             const Evaluation& pg = priVars.makeEvaluation(Indices::pressureSwitchIdx, timeIdx);
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
                 if (FluidSystem::phaseIsActive(phaseIdx))
@@ -265,7 +265,7 @@ public:
 
         // take the meaning of the switching primary variable into account for the gas
         // and oil phase compositions
-        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Rs) {
+        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Rs) {
             const auto& Rs = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
             fluidState_.setRs(Rs);
         } else {
@@ -281,7 +281,7 @@ public:
                 fluidState_.setRs(0.0);
         }
 
-        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Rv) {
+        if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Rv) {
             const auto& Rv = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
             fluidState_.setRv(Rv);
         } else {
@@ -297,7 +297,7 @@ public:
                 fluidState_.setRv(0.0);
         }
 
-        if (priVars.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Rvw) {
+        if (priVars.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Rvw) {
             const auto& Rvw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
             fluidState_.setRvw(Rvw);
         } else {
@@ -414,7 +414,7 @@ public:
         }
 
         // deal with salt-precipitation
-        if (enableSaltPrecipitation && priVars.primaryVarsMeaningBrine() == PrimaryVariables::PrimaryVarsMeaningBrine::Sp) {
+        if (enableSaltPrecipitation && priVars.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp) {
             Evaluation Sp = priVars.makeEvaluation(Indices::saltConcentrationIdx, timeIdx);
             porosity_ *= (1.0 - Sp);
         }

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -423,13 +423,13 @@ public:
         // if the primary variable is either the gas saturation, Rs or Rv
         assert(int(Indices::compositionSwitchIdx) == int(pvIdx));
 
-        auto pvMeaning = this->solution(0)[globalDofIdx].primaryVarsMeaning();
-        if (pvMeaning == PrimaryVariables::Sw_po_Sg)
+        auto pvMeaning = this->solution(0)[globalDofIdx].primaryVarsMeaningGas();
+        if (pvMeaning == PrimaryVariables::Sg)
             return 1.0; // gas saturation
-        else if (pvMeaning == PrimaryVariables::Sw_po_Rs)
+        else if (pvMeaning == PrimaryVariables::Rs)
             return 1.0/250.; // gas dissolution factor
         else {
-            assert(pvMeaning == PrimaryVariables::Sw_pg_Rv);
+            assert(pvMeaning == PrimaryVariables::Rv);
             return 1.0/0.025; // oil vaporization factor
         }
 
@@ -475,7 +475,10 @@ public:
             outstream << priVars[eqIdx] << " ";
 
         // write the pseudo primary variables
-        outstream << priVars.primaryVarsMeaning() << " ";
+        outstream << priVars.primaryVarsMeaningGas() << " ";
+        outstream << priVars.primaryVarsMeaningWater() << " ";
+        outstream << priVars.primaryVarsMeaningPressure() << " ";
+
         outstream << priVars.pvtRegionIndex() << " ";
 
         SolventModule::serializeEntity(*this, outstream, dof);
@@ -507,8 +510,14 @@ public:
         }
 
         // read the pseudo primary variables
-        unsigned primaryVarsMeaning;
-        instream >> primaryVarsMeaning;
+        unsigned primaryVarsMeaningGas;
+        instream >> primaryVarsMeaningGas;
+
+        unsigned primaryVarsMeaningWater;
+        instream >> primaryVarsMeaningWater;
+
+        unsigned primaryVarsMeaningPressure;
+        instream >> primaryVarsMeaningPressure;
 
         unsigned pvtRegionIdx;
         instream >> pvtRegionIdx;
@@ -521,8 +530,13 @@ public:
         PolymerModule::deserializeEntity(*this, instream, dof);
         EnergyModule::deserializeEntity(*this, instream, dof);
 
-        using PVM = typename PrimaryVariables::PrimaryVarsMeaning;
-        priVars.setPrimaryVarsMeaning(static_cast<PVM>(primaryVarsMeaning));
+        using PVM_G = typename PrimaryVariables::PrimaryVarsMeaningGas;
+        using PVM_W = typename PrimaryVariables::PrimaryVarsMeaningWater;
+        using PVM_P = typename PrimaryVariables::PrimaryVarsMeaningPressure;
+        priVars.setPrimaryVarsMeaningGas(static_cast<PVM_G>(primaryVarsMeaningGas));
+        priVars.setPrimaryVarsMeaningWater(static_cast<PVM_W>(primaryVarsMeaningWater));
+        priVars.setPrimaryVarsMeaningPressure(static_cast<PVM_P>(primaryVarsMeaningPressure));
+
         priVars.setPvtRegionIndex(pvtRegionIdx);
     }
 

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -424,12 +424,12 @@ public:
         assert(int(Indices::compositionSwitchIdx) == int(pvIdx));
 
         auto pvMeaning = this->solution(0)[globalDofIdx].primaryVarsMeaningGas();
-        if (pvMeaning == PrimaryVariables::PrimaryVarsMeaningGas::Sg)
+        if (pvMeaning == PrimaryVariables::GasMeaning::Sg)
             return 1.0; // gas saturation
-        else if (pvMeaning == PrimaryVariables::PrimaryVarsMeaningGas::Rs)
+        else if (pvMeaning == PrimaryVariables::GasMeaning::Rs)
             return 1.0/250.; // gas dissolution factor
         else {
-            assert(pvMeaning == PrimaryVariables::PrimaryVarsMeaningGas::Rv);
+            assert(pvMeaning == PrimaryVariables::GasMeaning::Rv);
             return 1.0/0.025; // oil vaporization factor
         }
 
@@ -530,9 +530,9 @@ public:
         PolymerModule::deserializeEntity(*this, instream, dof);
         EnergyModule::deserializeEntity(*this, instream, dof);
 
-        using PVM_G = typename PrimaryVariables::PrimaryVarsMeaningGas;
-        using PVM_W = typename PrimaryVariables::PrimaryVarsMeaningWater;
-        using PVM_P = typename PrimaryVariables::PrimaryVarsMeaningPressure;
+        using PVM_G = typename PrimaryVariables::GasMeaning;
+        using PVM_W = typename PrimaryVariables::WaterMeaning;
+        using PVM_P = typename PrimaryVariables::PressureMeaning;
         priVars.setPrimaryVarsMeaningGas(static_cast<PVM_G>(primaryVarsMeaningGas));
         priVars.setPrimaryVarsMeaningWater(static_cast<PVM_W>(primaryVarsMeaningWater));
         priVars.setPrimaryVarsMeaningPressure(static_cast<PVM_P>(primaryVarsMeaningPressure));

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -343,7 +343,7 @@ public:
         std::ostringstream oss;
 
         if (pvIdx == Indices::waterSwitchIdx)
-            oss << "saturation_" << FluidSystem::phaseName(FluidSystem::waterPhaseIdx);
+            oss << "water_switching";
         else if (pvIdx == Indices::pressureSwitchIdx)
             oss << "pressure_switching";
         else if (static_cast<int>(pvIdx) == Indices::compositionSwitchIdx)
@@ -424,12 +424,12 @@ public:
         assert(int(Indices::compositionSwitchIdx) == int(pvIdx));
 
         auto pvMeaning = this->solution(0)[globalDofIdx].primaryVarsMeaningGas();
-        if (pvMeaning == PrimaryVariables::Sg)
+        if (pvMeaning == PrimaryVariables::PrimaryVarsMeaningGas::Sg)
             return 1.0; // gas saturation
-        else if (pvMeaning == PrimaryVariables::Rs)
+        else if (pvMeaning == PrimaryVariables::PrimaryVarsMeaningGas::Rs)
             return 1.0/250.; // gas dissolution factor
         else {
-            assert(pvMeaning == PrimaryVariables::Rv);
+            assert(pvMeaning == PrimaryVariables::PrimaryVarsMeaningGas::Rv);
             return 1.0/0.025; // oil vaporization factor
         }
 
@@ -475,9 +475,9 @@ public:
             outstream << priVars[eqIdx] << " ";
 
         // write the pseudo primary variables
-        outstream << priVars.primaryVarsMeaningGas() << " ";
-        outstream << priVars.primaryVarsMeaningWater() << " ";
-        outstream << priVars.primaryVarsMeaningPressure() << " ";
+        outstream << static_cast<int>(priVars.primaryVarsMeaningGas()) << " ";
+        outstream << static_cast<int>(priVars.primaryVarsMeaningWater()) << " ";
+        outstream << static_cast<int>(priVars.primaryVarsMeaningPressure()) << " ";
 
         outstream << priVars.pvtRegionIndex() << " ";
 

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -342,7 +342,7 @@ public:
     {
         std::ostringstream oss;
 
-        if (pvIdx == Indices::waterSaturationIdx)
+        if (pvIdx == Indices::waterSwitchIdx)
             oss << "saturation_" << FluidSystem::phaseName(FluidSystem::waterPhaseIdx);
         else if (pvIdx == Indices::pressureSwitchIdx)
             oss << "pressure_switching";
@@ -396,7 +396,7 @@ public:
             return 1.0;
 
         // saturations are always in the range [0, 1]!
-        if (int(Indices::waterSaturationIdx) == int(pvIdx))
+        if (int(Indices::waterSwitchIdx) == int(pvIdx))
             return 1.0;
 
         // oil pressures usually are in the range of 100 to 500 bars for typical oil

--- a/opm/models/blackoil/blackoilnewtonmethod.hh
+++ b/opm/models/blackoil/blackoilnewtonmethod.hh
@@ -263,7 +263,7 @@ protected:
 
         if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::Sw)
         {
-            deltaSw = update[Indices::waterSaturationIdx];
+            deltaSw = update[Indices::waterSwitchIdx];
             deltaSo -= deltaSw;
         }
         if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::Sg)
@@ -302,13 +302,13 @@ protected:
                     delta = signum(delta)*dpMaxRel_*currentValue[pvIdx];
             }
             // water saturation delta
-            else if (pvIdx == Indices::waterSaturationIdx)
+            else if (pvIdx == Indices::waterSwitchIdx)
                 if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::Sw)
                     delta *= satAlpha;
                 else {
                     //Ensure Rvw factor does not become negative
-                    if (delta > currentValue[ Indices::waterSaturationIdx]) 
-                        delta = currentValue[ Indices::waterSaturationIdx];
+                    if (delta > currentValue[ Indices::waterSwitchIdx]) 
+                        delta = currentValue[ Indices::waterSwitchIdx];
                 }
             else if (pvIdx == Indices::compositionSwitchIdx) {
                 // the switching primary variable for composition is tricky because the

--- a/opm/models/blackoil/blackoilnewtonmethod.hh
+++ b/opm/models/blackoil/blackoilnewtonmethod.hh
@@ -261,12 +261,12 @@ protected:
         Scalar deltaSg = 0.0;
         Scalar deltaSs = 0.0;
 
-        if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Sw)
+        if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw)
         {
             deltaSw = update[Indices::waterSwitchIdx];
             deltaSo -= deltaSw;
         }
-        if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Sg)
+        if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
         {
             deltaSg = update[Indices::compositionSwitchIdx];
             deltaSo -= deltaSg;
@@ -303,7 +303,7 @@ protected:
             }
             // water saturation delta
             else if (pvIdx == Indices::waterSwitchIdx)
-                if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Sw)
+                if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw)
                     delta *= satAlpha;
                 else {
                     //Ensure Rvw factor does not become negative
@@ -316,7 +316,7 @@ protected:
                 // interpretation since it can represent Sg, Rs or Rv. For now, we only
                 // limit saturation deltas and ensure that the R factors do not become
                 // negative.
-                if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Sg)
+                if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
                     delta *= satAlpha;
                 else {
                     //Ensure Rv and Rs factor does not become negative
@@ -348,7 +348,7 @@ protected:
             }
             else if (enableBrine && pvIdx == Indices::saltConcentrationIdx &&
                      enableSaltPrecipitation &&
-                     currentValue.primaryVarsMeaningBrine() == PrimaryVariables::PrimaryVarsMeaningBrine::Sp) {
+                     currentValue.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp) {
                 const double maxSaltSaturationChange = 0.1;
                 const double sign = delta >= 0. ? 1. : -1.;
                 delta = sign * std::min(std::abs(delta), maxSaltSaturationChange);
@@ -382,10 +382,10 @@ protected:
 
             if (enableBrine && pvIdx == Indices::saltConcentrationIdx) { 
                // keep the salt concentration above 0
-               if (!enableSaltPrecipitation || (enableSaltPrecipitation && currentValue.primaryVarsMeaningBrine() == PrimaryVariables::PrimaryVarsMeaningBrine::Cs))
+               if (!enableSaltPrecipitation || (enableSaltPrecipitation && currentValue.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Cs))
                    nextValue[pvIdx] = std::max(nextValue[pvIdx], 0.0); 
                // keep the salt saturation below upperlimit
-               if ((enableSaltPrecipitation && currentValue.primaryVarsMeaningBrine() == PrimaryVariables::PrimaryVarsMeaningBrine::Sp))
+               if ((enableSaltPrecipitation && currentValue.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp))
                    nextValue[pvIdx] = std::min(nextValue[pvIdx], 1.0-1.e-8); 
             }
 

--- a/opm/models/blackoil/blackoilnewtonmethod.hh
+++ b/opm/models/blackoil/blackoilnewtonmethod.hh
@@ -261,12 +261,12 @@ protected:
         Scalar deltaSg = 0.0;
         Scalar deltaSs = 0.0;
 
-        if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::Sw)
+        if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Sw)
         {
             deltaSw = update[Indices::waterSwitchIdx];
             deltaSo -= deltaSw;
         }
-        if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::Sg)
+        if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Sg)
         {
             deltaSg = update[Indices::compositionSwitchIdx];
             deltaSo -= deltaSg;
@@ -303,7 +303,7 @@ protected:
             }
             // water saturation delta
             else if (pvIdx == Indices::waterSwitchIdx)
-                if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::Sw)
+                if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::PrimaryVarsMeaningWater::Sw)
                     delta *= satAlpha;
                 else {
                     //Ensure Rvw factor does not become negative
@@ -316,7 +316,7 @@ protected:
                 // interpretation since it can represent Sg, Rs or Rv. For now, we only
                 // limit saturation deltas and ensure that the R factors do not become
                 // negative.
-                if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::Sg)
+                if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::PrimaryVarsMeaningGas::Sg)
                     delta *= satAlpha;
                 else {
                     //Ensure Rv and Rs factor does not become negative
@@ -348,7 +348,7 @@ protected:
             }
             else if (enableBrine && pvIdx == Indices::saltConcentrationIdx &&
                      enableSaltPrecipitation &&
-                     currentValue.primaryVarsMeaningBrine() == PrimaryVariables::Sp) {
+                     currentValue.primaryVarsMeaningBrine() == PrimaryVariables::PrimaryVarsMeaningBrine::Sp) {
                 const double maxSaltSaturationChange = 0.1;
                 const double sign = delta >= 0. ? 1. : -1.;
                 delta = sign * std::min(std::abs(delta), maxSaltSaturationChange);
@@ -382,10 +382,10 @@ protected:
 
             if (enableBrine && pvIdx == Indices::saltConcentrationIdx) { 
                // keep the salt concentration above 0
-               if (!enableSaltPrecipitation || (enableSaltPrecipitation && currentValue.primaryVarsMeaningBrine() == PrimaryVariables::Cs))
+               if (!enableSaltPrecipitation || (enableSaltPrecipitation && currentValue.primaryVarsMeaningBrine() == PrimaryVariables::PrimaryVarsMeaningBrine::Cs))
                    nextValue[pvIdx] = std::max(nextValue[pvIdx], 0.0); 
                // keep the salt saturation below upperlimit
-               if ((enableSaltPrecipitation && currentValue.primaryVarsMeaningBrine() == PrimaryVariables::Sp))
+               if ((enableSaltPrecipitation && currentValue.primaryVarsMeaningBrine() == PrimaryVariables::PrimaryVarsMeaningBrine::Sp))
                    nextValue[pvIdx] = std::min(nextValue[pvIdx], 1.0-1.e-8); 
             }
 

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -92,7 +92,7 @@ struct BlackOilOnePhaseIndices
     //////////////////////////////
 
     //! The index of the water saturation. For two-phase oil gas models this is disabled.
-    static const int waterSaturationIdx  = -10000;
+    static const int waterSwitchIdx  = -10000;
 
     //! Index of the oil pressure in a vector of primary variables
     static const int pressureSwitchIdx  = PVOffset + 0;

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -91,17 +91,29 @@ struct BlackOilOnePhaseIndices
     // Primary variable indices
     //////////////////////////////
 
-    //! The index of the water saturation. For two-phase oil gas models this is disabled.
+    /*!
+     * \brief Index of the switching variable which determines the composistion of the water phase
+     *
+     * Depending on the phases present, this variable is either interpreted as
+     * water saturation or vapporized water in gas phase.
+     *
+     * \note For one-phase models this is disabled.
+     */
     static const int waterSwitchIdx  = -10000;
 
-    //! Index of the oil pressure in a vector of primary variables
-    static const int pressureSwitchIdx  = PVOffset + 0;
+    /*!
+     * \brief Index of the switching variable which determines the pressure
+     *
+     * Depending on the phases present, this variable is either interpreted as the
+     * pressure of the oil phase, gas phase (if no oil) or water phase (if only water)
+     */
+     static const int pressureSwitchIdx  = PVOffset + 0;
 
     /*!
      * \brief Index of the switching variable which determines the composition of the
      *        hydrocarbon phases.
      *
-     * \note For two-phase water oil models this is disabled.
+     * \note For one-phase models this is disabled.
      */
     static const int compositionSwitchIdx = -10000;
 

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -79,7 +79,7 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag>
     enum { numEq = getPropValue<TypeTag, Properties::NumEq>() };
 
     // primary variable indices
-    enum { waterSaturationIdx = Indices::waterSaturationIdx };
+    enum { waterSwitchIdx = Indices::waterSwitchIdx };
     enum { pressureSwitchIdx = Indices::pressureSwitchIdx };
     enum { compositionSwitchIdx = Indices::compositionSwitchIdx };
     enum { saltConcentrationIdx  = Indices::saltConcentrationIdx };
@@ -406,13 +406,13 @@ public:
         switch(primaryVarsMeaningWater()) {
             case Sw:
             {
-                (*this)[waterSaturationIdx] = FsToolbox::value(fluidState.saturation(waterPhaseIdx));
+                (*this)[waterSwitchIdx] = FsToolbox::value(fluidState.saturation(waterPhaseIdx));
                 break;
             }
             case Rvw:
             {
                 const auto& rvw = BlackOil::getRvw_<FluidSystem, FluidState, Scalar>(fluidState, pvtRegionIdx_);
-                (*this)[waterSaturationIdx] = rvw;
+                (*this)[waterSwitchIdx] = rvw;
                 break;
             }
             case W_disabled:
@@ -443,7 +443,7 @@ public:
             //case Rsw:
             //{
                 //const auto& Rsw = BlackOil::getRsw_<FluidSystem, FluidState, Scalar>(fluidState, pvtRegionIdx_);
-                //(*this)[waterSaturationIdx] = Rsw;
+                //(*this)[waterSwitchIdx] = Rsw;
             //    break;
             //}
             case G_disabled:
@@ -486,7 +486,7 @@ public:
         Scalar saltConcentration = 0.0;
         const Scalar& T = asImp_().temperature_();
         if (primaryVarsMeaningWater() == Sw)
-            sw = (*this)[waterSaturationIdx];
+            sw = (*this)[waterSwitchIdx];
         if (primaryVarsMeaningGas() == Sg)
             sg = (*this)[compositionSwitchIdx];
 
@@ -518,7 +518,7 @@ public:
 
             // make sure water saturations does not exceed 1.0
             if constexpr (waterEnabled)
-                (*this)[Indices::waterSaturationIdx] = 1.0;
+                (*this)[Indices::waterSwitchIdx] = 1.0;
             // the hydrocarbon gas saturation is set to 0.0
             if constexpr (compositionSwitchEnabled)
                 (*this)[Indices::compositionSwitchIdx] = 0.0;
@@ -554,7 +554,7 @@ public:
                                                                                    p,
                                                                                    saltConcentration);
                     setPrimaryVarsMeaningWater(Rvw);
-                    (*this)[Indices::waterSaturationIdx] = rvwSat; //primary variable becomes Rvw
+                    (*this)[Indices::waterSwitchIdx] = rvwSat; //primary variable becomes Rvw
                     changed = true;
                     break;
                 }
@@ -570,7 +570,7 @@ public:
                 //                                                                   pw,
                 //                                                                   saltConcentration);
                 //    setPrimaryVarsMeaningWater(Rsw);
-                //    (*this)[Indices::waterSaturationIdx] = rswSat; //primary variable becomes Rsw
+                //    (*this)[Indices::waterSwitchIdx] = rswSat; //primary variable becomes Rsw
                 //    changed = true;
                 //    break;
                 //}
@@ -578,7 +578,7 @@ public:
             }
             case Rvw:
             {
-                const Scalar& rvw = (*this)[waterSaturationIdx];
+                const Scalar& rvw = (*this)[waterSwitchIdx];
                 Scalar p = (*this)[pressureSwitchIdx];
                 if(primaryVarsMeaningPressure() == Po) {
                     std::array<Scalar, numPhases> pC = { 0.0 };
@@ -594,7 +594,7 @@ public:
                 if (rvw > rvwSat*(1.0 + eps)) {
                     // water phase appears
                     setPrimaryVarsMeaningWater(Sw);
-                    (*this)[Indices::waterSaturationIdx] = 0.0; // water saturation
+                    (*this)[Indices::waterSwitchIdx] = 0.0; // water saturation
                     changed = true;
                 }
                 break;
@@ -748,7 +748,7 @@ public:
         }
         Scalar sw = 0.0;
         if (primaryVarsMeaningWater() == Sw)
-            sw = (*this)[Indices::waterSaturationIdx];
+            sw = (*this)[Indices::waterSwitchIdx];
         Scalar sg = 0.0;
         if (primaryVarsMeaningGas() == Sg)
             sg = (*this)[Indices::compositionSwitchIdx];
@@ -768,7 +768,7 @@ public:
         ssol = ssol/st;
         assert(st>0.5);
         if (primaryVarsMeaningWater() == Sw)
-            (*this)[Indices::waterSaturationIdx] = sw;
+            (*this)[Indices::waterSwitchIdx] = sw;
         if (primaryVarsMeaningGas() == Sg)
             (*this)[Indices::compositionSwitchIdx] = sg;
         if constexpr (enableSolvent)

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -124,18 +124,18 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag>
     static_assert(numComponents == 3, "The black-oil model assumes three components!");
 
 public:
-    enum class PrimaryVarsMeaningWater {
+    enum class WaterMeaning {
         Sw,  // water saturation
         Rvw, // vaporized water
         Disabled, // The primary variable is not used
     };
 
-    enum class PrimaryVarsMeaningPressure {
+    enum class PressureMeaning {
         Po, // oil pressure
         Pg, // gas pressure
         Pw, // water pressure
     };
-    enum class PrimaryVarsMeaningGas {
+    enum class GasMeaning {
         Sg, // gas saturation
         Rs, // dissolved gas in oil
         //Rsw, // dissolved gas in water
@@ -143,7 +143,7 @@ public:
         Disabled, // The primary variable is not used
     };
 
-    enum class PrimaryVarsMeaningBrine {
+    enum class BrineMeaning {
         Cs, // salt concentration
         Sp, // (precipitated) salt saturation
         Disabled, // The primary variable is not used
@@ -196,45 +196,45 @@ public:
      * \brief Return the interpretation which should be applied to the switching primary
      *        variables.
      */
-    PrimaryVarsMeaningWater primaryVarsMeaningWater() const
+    WaterMeaning primaryVarsMeaningWater() const
     { return primaryVarsMeaningWater_; }
 
     /*!
      * \brief Set the interpretation which should be applied to the switching primary
      *        variables.
      */
-    void setPrimaryVarsMeaningWater(PrimaryVarsMeaningWater newMeaning)
+    void setPrimaryVarsMeaningWater(WaterMeaning newMeaning)
     { primaryVarsMeaningWater_ = newMeaning; }
 
      /*!
      * \brief Return the interpretation which should be applied to the switching primary
      *        variables.
      */
-    PrimaryVarsMeaningPressure primaryVarsMeaningPressure() const
+    PressureMeaning primaryVarsMeaningPressure() const
     { return primaryVarsMeaningPressure_; }
 
     /*!
      * \brief Set the interpretation which should be applied to the switching primary
      *        variables.
      */
-    void setPrimaryVarsMeaningPressure(PrimaryVarsMeaningPressure newMeaning)
+    void setPrimaryVarsMeaningPressure(PressureMeaning newMeaning)
     { primaryVarsMeaningPressure_ = newMeaning; }
 
      /*!
      * \brief Return the interpretation which should be applied to the switching primary
      *        variables.
      */
-    PrimaryVarsMeaningGas primaryVarsMeaningGas() const
+    GasMeaning primaryVarsMeaningGas() const
     { return primaryVarsMeaningGas_; }
 
     /*!
      * \brief Set the interpretation which should be applied to the switching primary
      *        variables.
      */
-    void setPrimaryVarsMeaningGas(PrimaryVarsMeaningGas newMeaning)
+    void setPrimaryVarsMeaningGas(GasMeaning newMeaning)
     { primaryVarsMeaningGas_ = newMeaning; }
 
-    PrimaryVarsMeaningBrine primaryVarsMeaningBrine() const
+    BrineMeaning primaryVarsMeaningBrine() const
     { return primaryVarsMeaningBrine_; }
 
     /*!
@@ -242,7 +242,7 @@ public:
      *        variables.
      */
 
-    void setPrimaryVarsMeaningBrine(PrimaryVarsMeaningBrine newMeaning)
+    void setPrimaryVarsMeaningBrine(BrineMeaning newMeaning)
     { primaryVarsMeaningBrine_ = newMeaning; }
 
     /*!
@@ -344,78 +344,78 @@ public:
 
         // determine the meaning of the primary variables
         if (gasPresent && FluidSystem::enableVaporizedOil() && !oilPresent){
-            primaryVarsMeaningPressure_ = PrimaryVarsMeaningPressure::Pg;
+            primaryVarsMeaningPressure_ = PressureMeaning::Pg;
         } else if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
-            primaryVarsMeaningPressure_ = PrimaryVarsMeaningPressure::Po;
+            primaryVarsMeaningPressure_ = PressureMeaning::Po;
         } else if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
-            primaryVarsMeaningPressure_ = PrimaryVarsMeaningPressure::Pg;
+            primaryVarsMeaningPressure_ = PressureMeaning::Pg;
         } else {
             assert(FluidSystem::phaseIsActive(waterPhaseIdx));
-            primaryVarsMeaningPressure_ = PrimaryVarsMeaningPressure::Pw;
+            primaryVarsMeaningPressure_ = PressureMeaning::Pw;
         }
 
         // determine the meaning of the primary variables
         if ( waterPresent && gasPresent ){
-            primaryVarsMeaningWater_ = PrimaryVarsMeaningWater::Sw;
+            primaryVarsMeaningWater_ = WaterMeaning::Sw;
         } else if (gasPresent && FluidSystem::enableVaporizedWater()) {
-            primaryVarsMeaningWater_ = PrimaryVarsMeaningWater::Rvw;
+            primaryVarsMeaningWater_ = WaterMeaning::Rvw;
         } else if (FluidSystem::phaseIsActive(waterPhaseIdx) && !oneActivePhases) {
-            primaryVarsMeaningWater_ = PrimaryVarsMeaningWater::Sw;
+            primaryVarsMeaningWater_ = WaterMeaning::Sw;
         } else {
-            primaryVarsMeaningWater_ = PrimaryVarsMeaningWater::Disabled;
+            primaryVarsMeaningWater_ = WaterMeaning::Disabled;
         }
 
         // determine the meaning of the primary variables
         if ( gasPresent && oilPresent ) {
-            primaryVarsMeaningGas_ = PrimaryVarsMeaningGas::Sg;
+            primaryVarsMeaningGas_ = GasMeaning::Sg;
         } else if (oilPresent && FluidSystem::enableDissolvedGas()) {
-            primaryVarsMeaningGas_ = PrimaryVarsMeaningGas::Rs;
+            primaryVarsMeaningGas_ = GasMeaning::Rs;
         } else if (gasPresent && FluidSystem::enableVaporizedOil()){
-            primaryVarsMeaningGas_ = PrimaryVarsMeaningGas::Rv;
+            primaryVarsMeaningGas_ = GasMeaning::Rv;
         //} else if (waterPresent && FluidSystem::enableDissolvedGasInWater()) {
         //    primaryVarsMeaningGas_ = Rsw;
         } else if (FluidSystem::phaseIsActive(gasPhaseIdx) && FluidSystem::phaseIsActive(oilPhaseIdx)) {
-            primaryVarsMeaningGas_ = PrimaryVarsMeaningGas::Sg;
+            primaryVarsMeaningGas_ = GasMeaning::Sg;
         } else {
-            primaryVarsMeaningGas_ = PrimaryVarsMeaningGas::Disabled;
+            primaryVarsMeaningGas_ = GasMeaning::Disabled;
         }
 
         if constexpr (enableSaltPrecipitation){
             if (precipitatedSaltPresent)
-                primaryVarsMeaningBrine_ = PrimaryVarsMeaningBrine::Sp;
+                primaryVarsMeaningBrine_ = BrineMeaning::Sp;
             else
-                primaryVarsMeaningBrine_ = PrimaryVarsMeaningBrine::Cs;
+                primaryVarsMeaningBrine_ = BrineMeaning::Cs;
         } else {
-            primaryVarsMeaningBrine_ = PrimaryVarsMeaningBrine::Disabled;
+            primaryVarsMeaningBrine_ = BrineMeaning::Disabled;
         }
 
         // assign the actual primary variables
         switch(primaryVarsMeaningPressure()) {
-            case PrimaryVarsMeaningPressure::Po:
+            case PressureMeaning::Po:
                 (*this)[pressureSwitchIdx] = FsToolbox::value(fluidState.pressure(oilPhaseIdx));
                 break;
-            case PrimaryVarsMeaningPressure::Pg:
+            case PressureMeaning::Pg:
                 (*this)[pressureSwitchIdx] = FsToolbox::value(fluidState.pressure(gasPhaseIdx));
                 break;
-            case PrimaryVarsMeaningPressure::Pw:
+            case PressureMeaning::Pw:
                 (*this)[pressureSwitchIdx] = FsToolbox::value(fluidState.pressure(waterPhaseIdx));
                 break;
             default:
                 throw std::logic_error("No valid primary variable selected for pressure");
         }
         switch(primaryVarsMeaningWater()) {
-            case PrimaryVarsMeaningWater::Sw:
+            case WaterMeaning::Sw:
             {
                 (*this)[waterSwitchIdx] = FsToolbox::value(fluidState.saturation(waterPhaseIdx));
                 break;
             }
-            case PrimaryVarsMeaningWater::Rvw:
+            case WaterMeaning::Rvw:
             {
                 const auto& rvw = BlackOil::getRvw_<FluidSystem, FluidState, Scalar>(fluidState, pvtRegionIdx_);
                 (*this)[waterSwitchIdx] = rvw;
                 break;
             }
-            case PrimaryVarsMeaningWater::Disabled:
+            case WaterMeaning::Disabled:
             {
                 break;
             }
@@ -423,18 +423,18 @@ public:
                 throw std::logic_error("No valid primary variable selected for water");
         }
         switch(primaryVarsMeaningGas()) {
-            case PrimaryVarsMeaningGas::Sg:
+            case GasMeaning::Sg:
             {
                 (*this)[compositionSwitchIdx] = FsToolbox::value(fluidState.saturation(gasPhaseIdx));
                 break;
             }
-            case PrimaryVarsMeaningGas::Rs:
+            case GasMeaning::Rs:
             {
                 const auto& rs = BlackOil::getRs_<FluidSystem, FluidState, Scalar>(fluidState, pvtRegionIdx_);
                 (*this)[compositionSwitchIdx] = rs;
                 break;
             }
-            case PrimaryVarsMeaningGas::Rv:
+            case GasMeaning::Rv:
             {
                 const auto& rv = BlackOil::getRv_<FluidSystem, FluidState, Scalar>(fluidState, pvtRegionIdx_);
                 (*this)[compositionSwitchIdx] = rv;
@@ -446,7 +446,7 @@ public:
                 //(*this)[waterSwitchIdx] = Rsw;
             //    break;
             //}
-            case PrimaryVarsMeaningGas::Disabled:
+            case GasMeaning::Disabled:
             {
                 break;
             }
@@ -462,7 +462,7 @@ public:
      *
      * If the meaning of the primary variables changes, their values are also adapted in a
      * meaningful manner. (e.g. if the gas phase appears and the composition switching
-     * variable changes its meaning from the gas dissolution factor PrimaryVarsMeaningGas::Rs to the gas
+     * variable changes its meaning from the gas dissolution factor GasMeaning::Rs to the gas
      * saturation Sg, the value for this variable is set to zero.)
      * A Scalar eps can be passed to make the switching condition more strict.
      * Useful for avoiding ocsilation in the primaryVarsMeaning.
@@ -478,35 +478,35 @@ public:
         // the IntensiveQuantities). The reason is that most intensive quantities are not
         // required to be able to decide if the primary variables needs to be switched or
         // not, so it would be a waste to compute them.
-        if (primaryVarsMeaningWater() == PrimaryVarsMeaningWater::Disabled && primaryVarsMeaningGas() == PrimaryVarsMeaningGas::Disabled){
+        if (primaryVarsMeaningWater() == WaterMeaning::Disabled && primaryVarsMeaningGas() == GasMeaning::Disabled){
             return false;
         }
         Scalar sw = 0.0;
         Scalar sg = 0.0;
         Scalar saltConcentration = 0.0;
         const Scalar& T = asImp_().temperature_();
-        if (primaryVarsMeaningWater() == PrimaryVarsMeaningWater::Sw)
+        if (primaryVarsMeaningWater() == WaterMeaning::Sw)
             sw = (*this)[waterSwitchIdx];
-        if (primaryVarsMeaningGas() == PrimaryVarsMeaningGas::Sg)
+        if (primaryVarsMeaningGas() == GasMeaning::Sg)
             sg = (*this)[compositionSwitchIdx];
 
-        if (primaryVarsMeaningGas() == PrimaryVarsMeaningGas::Disabled && gasEnabled)
+        if (primaryVarsMeaningGas() == GasMeaning::Disabled && gasEnabled)
             sg = 1.0 - sw; // water + gas case
 
         if constexpr (enableSaltPrecipitation) {
             Scalar saltSolubility = BrineModule::saltSol(pvtRegionIndex());
-            if (primaryVarsMeaningBrine() == PrimaryVarsMeaningBrine::Sp) {
+            if (primaryVarsMeaningBrine() == BrineMeaning::Sp) {
                 saltConcentration = saltSolubility;
                 Scalar saltSat = (*this)[saltConcentrationIdx];
                 if (saltSat < -eps){ //precipitated salt dissappears
-                    setPrimaryVarsMeaningBrine(PrimaryVarsMeaningBrine::Cs);
+                    setPrimaryVarsMeaningBrine(BrineMeaning::Cs);
                     (*this)[saltConcentrationIdx] = saltSolubility; //set salt concentration to solubility limit
                 }
             }
-            else if (primaryVarsMeaningBrine() == PrimaryVarsMeaningBrine::Cs) {
+            else if (primaryVarsMeaningBrine() == BrineMeaning::Cs) {
                 saltConcentration = (*this)[saltConcentrationIdx];
                 if (saltConcentration > saltSolubility + eps){ //salt concentration exceeds solubility limit
-                    setPrimaryVarsMeaningBrine(PrimaryVarsMeaningBrine::Sp);
+                    setPrimaryVarsMeaningBrine(BrineMeaning::Sp);
                     (*this)[saltConcentrationIdx] = 0.0;
                 }
             }
@@ -524,25 +524,25 @@ public:
                 (*this)[Indices::compositionSwitchIdx] = 0.0;
 
             //const Scalar& po = (*this)[pressureSwitchIdx];
-            changed = primaryVarsMeaningWater() != PrimaryVarsMeaningWater::Sw || primaryVarsMeaningGas() != PrimaryVarsMeaningGas::Sg;
+            changed = primaryVarsMeaningWater() != WaterMeaning::Sw || primaryVarsMeaningGas() != GasMeaning::Sg;
             if(changed) {
                 if constexpr (waterEnabled)
-                    setPrimaryVarsMeaningWater(PrimaryVarsMeaningWater::Sw);
+                    setPrimaryVarsMeaningWater(WaterMeaning::Sw);
                 if constexpr (compositionSwitchEnabled)
-                    setPrimaryVarsMeaningGas(PrimaryVarsMeaningGas::Sg);
+                    setPrimaryVarsMeaningGas(GasMeaning::Sg);
 
-                //setPrimaryVarsMeaningPressure(PrimaryVarsMeaningPressure::Po);
+                //setPrimaryVarsMeaningPressure(PressureMeaning::Po);
                 // use water pressure?
             }
             return changed;
         }
 
         switch(primaryVarsMeaningWater()) {
-            case PrimaryVarsMeaningWater::Sw:
+            case WaterMeaning::Sw:
             {
                 if(sw < -eps && sg > eps && FluidSystem::enableVaporizedWater()) {
                     Scalar p = (*this)[pressureSwitchIdx];
-                    if(primaryVarsMeaningPressure() == PrimaryVarsMeaningPressure::Po) {
+                    if(primaryVarsMeaningPressure() == PressureMeaning::Po) {
                         std::array<Scalar, numPhases> pC = { 0.0 };
                         const MaterialLawParams& matParams = problem.materialLawParams(globalDofIdx);
                         Scalar so = 1.0 - sg - solventSaturation_();
@@ -553,7 +553,7 @@ public:
                                                                                    T,
                                                                                    p,
                                                                                    saltConcentration);
-                    setPrimaryVarsMeaningWater(PrimaryVarsMeaningWater::Rvw);
+                    setPrimaryVarsMeaningWater(WaterMeaning::Rvw);
                     (*this)[Indices::waterSwitchIdx] = rvwSat; //primary variable becomes Rvw
                     changed = true;
                     break;
@@ -576,11 +576,11 @@ public:
                 //}
                 break;
             }
-            case PrimaryVarsMeaningWater::Rvw:
+            case WaterMeaning::Rvw:
             {
                 const Scalar& rvw = (*this)[waterSwitchIdx];
                 Scalar p = (*this)[pressureSwitchIdx];
-                if(primaryVarsMeaningPressure() == PrimaryVarsMeaningPressure::Po) {
+                if(primaryVarsMeaningPressure() == PressureMeaning::Po) {
                     std::array<Scalar, numPhases> pC = { 0.0 };
                     const MaterialLawParams& matParams = problem.materialLawParams(globalDofIdx);
                     Scalar so = 1.0 - sg - solventSaturation_();
@@ -593,13 +593,13 @@ public:
                                                                                    saltConcentration);
                 if (rvw > rvwSat*(1.0 + eps)) {
                     // water phase appears
-                    setPrimaryVarsMeaningWater(PrimaryVarsMeaningWater::Sw);
+                    setPrimaryVarsMeaningWater(WaterMeaning::Sw);
                     (*this)[Indices::waterSwitchIdx] = 0.0; // water saturation
                     changed = true;
                 }
                 break;
             }
-            case PrimaryVarsMeaningWater::Disabled:
+            case WaterMeaning::Disabled:
             {
                 break;
             }
@@ -608,12 +608,12 @@ public:
         }
 
         switch(primaryVarsMeaningGas()) {
-            case PrimaryVarsMeaningGas::Sg:
+            case GasMeaning::Sg:
             {
                 Scalar s = 1.0 - sw - solventSaturation_();
                 if (sg < -eps && s > 0.0 && FluidSystem::enableDissolvedGas()) {
                     const Scalar& po = (*this)[pressureSwitchIdx];
-                    setPrimaryVarsMeaningGas(PrimaryVarsMeaningGas::Rs);
+                    setPrimaryVarsMeaningGas(GasMeaning::Rs);
                     Scalar soMax = problem.maxOilSaturation(globalDofIdx);
                     Scalar rsMax = problem.maxGasDissolutionFactor(/*timeIdx=*/0, globalDofIdx);
                     Scalar rsSat = enableExtbo ? ExtboModule::rs(pvtRegionIndex(),
@@ -630,7 +630,7 @@ public:
                 Scalar so = 1.0 - sw - solventSaturation_() - sg;
                 if (so < -eps && sg > 0.0 && FluidSystem::enableVaporizedOil()) {
                     // the oil phase disappeared and some hydrocarbon gas phase is still
-                    // present, i.e., switch the primary variables to PrimaryVarsMeaningGas::Rv.
+                    // present, i.e., switch the primary variables to GasMeaning::Rv.
                     // we only have the oil pressure readily available, but we need the gas
                     // pressure, i.e. we must determine capillary pressure
                     const Scalar& po = (*this)[pressureSwitchIdx];
@@ -639,9 +639,9 @@ public:
                     computeCapillaryPressures_(pC, /*so=*/0.0, sg + solventSaturation_(), sw, matParams);
                     Scalar pg = po + (pC[gasPhaseIdx] - pC[oilPhaseIdx]);
 
-                    // we start at the PrimaryVarsMeaningGas::Rv value that corresponds to that of oil-saturated
+                    // we start at the GasMeaning::Rv value that corresponds to that of oil-saturated
                     // hydrocarbon gas
-                    setPrimaryVarsMeaningPressure(PrimaryVarsMeaningPressure::Pg);
+                    setPrimaryVarsMeaningPressure(PressureMeaning::Pg);
                     (*this)[Indices::pressureSwitchIdx] = pg;
                     Scalar soMax = problem.maxOilSaturation(globalDofIdx);
                     Scalar rvMax = problem.maxOilVaporizationFactor(/*timeIdx=*/0, globalDofIdx);
@@ -653,13 +653,13 @@ public:
                                                                                         pg,
                                                                                         Scalar(0),
                                                                                         soMax);
-                    setPrimaryVarsMeaningGas(PrimaryVarsMeaningGas::Rv);
+                    setPrimaryVarsMeaningGas(GasMeaning::Rv);
                     (*this)[Indices::compositionSwitchIdx] = std::min(rvMax, rvSat);
                     changed = true;
                 }
                 break;
             }
-            case PrimaryVarsMeaningGas::Rs:
+            case GasMeaning::Rs:
             {
                 // Gas phase not present. The hydrocarbon gas phase
                 // appears as soon as more of the gas component is present in the oil phase
@@ -679,14 +679,14 @@ public:
 
                 Scalar rs = (*this)[Indices::compositionSwitchIdx];
                 if (rs > std::min(rsMax, rsSat*(1.0 + eps))) {
-                    // the gas phase appears, i.e., switch the primary variables to PrimaryVarsMeaningGas::Sg
-                    setPrimaryVarsMeaningGas(PrimaryVarsMeaningGas::Sg);
+                    // the gas phase appears, i.e., switch the primary variables to GasMeaning::Sg
+                    setPrimaryVarsMeaningGas(GasMeaning::Sg);
                     (*this)[Indices::compositionSwitchIdx] = 0.0; // hydrocarbon gas saturation
                     changed = true;
                 }
                 break;
             }
-            case PrimaryVarsMeaningGas::Rv:
+            case GasMeaning::Rv:
             {
                 // The oil phase appears as
                 // soon as more of the oil component is present in the hydrocarbon gas phase
@@ -719,8 +719,8 @@ public:
                                             matParams);
                     Scalar po = pg + (pC[oilPhaseIdx] - pC[gasPhaseIdx]);
 
-                    setPrimaryVarsMeaningGas(PrimaryVarsMeaningGas::Sg);
-                    setPrimaryVarsMeaningPressure(PrimaryVarsMeaningPressure::Po);
+                    setPrimaryVarsMeaningGas(GasMeaning::Sg);
+                    setPrimaryVarsMeaningPressure(PressureMeaning::Po);
                     (*this)[Indices::pressureSwitchIdx] = po;
                     (*this)[Indices::compositionSwitchIdx] = sg2; // hydrocarbon gas saturation
                     changed = true;
@@ -732,7 +732,7 @@ public:
                 //TODO
             //    break;
             //}
-            case PrimaryVarsMeaningGas::Disabled:
+            case GasMeaning::Disabled:
             {
                 break;
             }
@@ -743,15 +743,15 @@ public:
     }
 
     bool chopAndNormalizeSaturations(){
-        if (primaryVarsMeaningWater() == PrimaryVarsMeaningWater::Disabled && 
-            primaryVarsMeaningGas() == PrimaryVarsMeaningGas::Disabled){
+        if (primaryVarsMeaningWater() == WaterMeaning::Disabled && 
+            primaryVarsMeaningGas() == GasMeaning::Disabled){
             return false;
         }
         Scalar sw = 0.0;
-        if (primaryVarsMeaningWater() == PrimaryVarsMeaningWater::Sw)
+        if (primaryVarsMeaningWater() == WaterMeaning::Sw)
             sw = (*this)[Indices::waterSwitchIdx];
         Scalar sg = 0.0;
-        if (primaryVarsMeaningGas() == PrimaryVarsMeaningGas::Sg)
+        if (primaryVarsMeaningGas() == GasMeaning::Sg)
             sg = (*this)[Indices::compositionSwitchIdx];
 
         Scalar ssol = 0.0;
@@ -768,9 +768,9 @@ public:
         sg = sg/st;
         ssol = ssol/st;
         assert(st>0.5);
-        if (primaryVarsMeaningWater() == PrimaryVarsMeaningWater::Sw)
+        if (primaryVarsMeaningWater() == WaterMeaning::Sw)
             (*this)[Indices::waterSwitchIdx] = sw;
-        if (primaryVarsMeaningGas() == PrimaryVarsMeaningGas::Sg)
+        if (primaryVarsMeaningGas() == GasMeaning::Sg)
             (*this)[Indices::compositionSwitchIdx] = sg;
         if constexpr (enableSolvent)
             (*this) [Indices::solventSaturationIdx] = ssol;
@@ -933,10 +933,10 @@ private:
         MaterialLaw::capillaryPressures(result, matParams, fluidState);
     }
 
-    PrimaryVarsMeaningWater primaryVarsMeaningWater_;
-    PrimaryVarsMeaningPressure primaryVarsMeaningPressure_;
-    PrimaryVarsMeaningGas primaryVarsMeaningGas_;
-    PrimaryVarsMeaningBrine primaryVarsMeaningBrine_;
+    WaterMeaning primaryVarsMeaningWater_;
+    PressureMeaning primaryVarsMeaningPressure_;
+    GasMeaning primaryVarsMeaningGas_;
+    BrineMeaning primaryVarsMeaningBrine_;
     unsigned short pvtRegionIdx_;
 };
 

--- a/opm/models/blackoil/blackoilsolventmodules.hh
+++ b/opm/models/blackoil/blackoilsolventmodules.hh
@@ -733,7 +733,7 @@ public:
 
             //oil is the reference phase for pressure
             const auto linearizationType = elemCtx.linearizationType();
-            if (priVars.primaryVarsMeaning() == PrimaryVariables::Sw_pg_Rv)
+            if (priVars.primaryVarsMeaningPressure() == PrimaryVariables::Pg)
                 pgMisc = priVars.makeEvaluation(Indices::pressureSwitchIdx, timeIdx, linearizationType);
             else {
                 const Evaluation& po = priVars.makeEvaluation(Indices::pressureSwitchIdx, timeIdx, linearizationType);

--- a/opm/models/blackoil/blackoilsolventmodules.hh
+++ b/opm/models/blackoil/blackoilsolventmodules.hh
@@ -733,7 +733,7 @@ public:
 
             //oil is the reference phase for pressure
             const auto linearizationType = elemCtx.linearizationType();
-            if (priVars.primaryVarsMeaningPressure() == PrimaryVariables::Pg)
+            if (priVars.primaryVarsMeaningPressure() == PrimaryVariables::PressureMeaning::Pg)
                 pgMisc = priVars.makeEvaluation(Indices::pressureSwitchIdx, timeIdx, linearizationType);
             else {
                 const Evaluation& po = priVars.makeEvaluation(Indices::pressureSwitchIdx, timeIdx, linearizationType);

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -92,7 +92,7 @@ struct BlackOilTwoPhaseIndices
     //////////////////////////////
 
     //! The index of the water saturation. For two-phase oil gas models this is disabled.
-    static const int waterSaturationIdx  = waterEnabled ? PVOffset + 0 : -10000;
+    static const int waterSwitchIdx  = waterEnabled ? PVOffset + 0 : -10000;
 
     //! Index of the oil pressure in a vector of primary variables
     static const int pressureSwitchIdx  = waterEnabled ? PVOffset + 1 : PVOffset + 0;

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -91,10 +91,22 @@ struct BlackOilTwoPhaseIndices
     // Primary variable indices
     //////////////////////////////
 
-    //! The index of the water saturation. For two-phase oil gas models this is disabled.
+    /*!
+     * \brief Index of the switching variable which determines the composistion of the water phase
+     *
+     * Depending on the phases present, this variable is either interpreted as
+     * water saturation or vapporized water in gas phase
+     *
+     * \note For two-phase gas-oil models this is disabled.
+     */
     static const int waterSwitchIdx  = waterEnabled ? PVOffset + 0 : -10000;
 
-    //! Index of the oil pressure in a vector of primary variables
+    /*!
+     * \brief Index of the switching variable which determines the pressure
+     *
+     * Depending on the phases present, this variable is either interpreted as the
+     * pressure of the oil phase, gas phase (if no oil) or water phase (if only water)
+     */
     static const int pressureSwitchIdx  = waterEnabled ? PVOffset + 1 : PVOffset + 0;
 
     /*!

--- a/opm/models/io/vtkblackoilmodule.hh
+++ b/opm/models/io/vtkblackoilmodule.hh
@@ -294,11 +294,11 @@ public:
 
             if (primaryVarsMeaningOutput_()) {
                 primaryVarsMeaningWater_[globalDofIdx] =
-                    primaryVars.primaryVarsMeaningWater();
+                    static_cast<int>(primaryVars.primaryVarsMeaningWater());
                 primaryVarsMeaningGas_[globalDofIdx] =
-                    primaryVars.primaryVarsMeaningGas();
+                    static_cast<int>(primaryVars.primaryVarsMeaningGas());
                 primaryVarsMeaningPressure_[globalDofIdx] =
-                    primaryVars.primaryVarsMeaningPressure();
+                    static_cast<int>(primaryVars.primaryVarsMeaningPressure());
             }
         }
     }

--- a/opm/models/io/vtkblackoilmodule.hh
+++ b/opm/models/io/vtkblackoilmodule.hh
@@ -204,8 +204,11 @@ public:
             this->resizeScalarBuffer_(oilSaturationRatio_);
             this->resizeScalarBuffer_(gasSaturationRatio_);
         }
-        if (primaryVarsMeaningOutput_())
-            this->resizeScalarBuffer_(primaryVarsMeaning_);
+        if (primaryVarsMeaningOutput_()) {
+            this->resizeScalarBuffer_(primaryVarsMeaningPressure_);
+            this->resizeScalarBuffer_(primaryVarsMeaningWater_);
+            this->resizeScalarBuffer_(primaryVarsMeaningGas_);
+        }
     }
 
     /*!
@@ -289,9 +292,14 @@ public:
                 waterFormationVolumeFactor_[globalDofIdx] =
                     1.0/FluidSystem::template inverseFormationVolumeFactor<FluidState, Scalar>(fs, waterPhaseIdx, pvtRegionIdx);
 
-            if (primaryVarsMeaningOutput_())
-                primaryVarsMeaning_[globalDofIdx] =
-                    primaryVars.primaryVarsMeaning();
+            if (primaryVarsMeaningOutput_()) {
+                primaryVarsMeaningWater_[globalDofIdx] =
+                    primaryVars.primaryVarsMeaningWater();
+                primaryVarsMeaningGas_[globalDofIdx] =
+                    primaryVars.primaryVarsMeaningGas();
+                primaryVarsMeaningPressure_[globalDofIdx] =
+                    primaryVars.primaryVarsMeaningPressure();
+            }
         }
     }
 
@@ -327,8 +335,11 @@ public:
             this->commitScalarBuffer_(baseWriter, "saturation ratio_gas", gasSaturationRatio_);
         }
 
-        if (primaryVarsMeaningOutput_())
-            this->commitScalarBuffer_(baseWriter, "primary vars meaning", primaryVarsMeaning_);
+        if (primaryVarsMeaningOutput_()) {
+            this->commitScalarBuffer_(baseWriter, "primary vars meaning water", primaryVarsMeaningWater_);
+            this->commitScalarBuffer_(baseWriter, "primary vars meaning gas", primaryVarsMeaningGas_);
+            this->commitScalarBuffer_(baseWriter, "primary vars meaning pressure", primaryVarsMeaningPressure_);
+        }
     }
 
 private:
@@ -411,7 +422,11 @@ private:
     ScalarBuffer oilSaturationRatio_;
     ScalarBuffer gasSaturationRatio_;
 
-    ScalarBuffer primaryVarsMeaning_;
+    ScalarBuffer primaryVarsMeaningPressure_;
+    ScalarBuffer primaryVarsMeaningWater_;
+    ScalarBuffer primaryVarsMeaningGas_;
+
+
 };
 } // namespace Opm
 


### PR DESCRIPTION
The primary variable meaning enums are split into three waterMeaning, gasMeaning and pressureMeaning to allow for all combination of the variables. This simplify the code and logic it also make it easier to add more switching options.