### PR TITLE
Matrix direct access

### DIFF
--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -436,9 +436,9 @@ private:
             MatrixBlock bMat(0.0);
             ADVectorBlock adres(0.0);
             const IntensiveQuantities* intQuantsInP = model_().cachedIntensiveQuantities(globI, /*timeIdx*/ 0);
-            // if (intQuantsInP == nullptr) {
-            //     throw std::logic_error("Missing updated intensive quantities for cell " + std::to_string(globI));
-            // }
+            if (intQuantsInP == nullptr) {
+                throw std::logic_error("Missing updated intensive quantities for cell " + std::to_string(globI));
+            }
             const IntensiveQuantities& intQuantsIn = *intQuantsInP;
 
             // Flux term.

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -445,7 +445,7 @@ private:
             short loc = 0;
             for (const auto& nbInfo : nbInfos) {
                 unsigned globJ = nbInfo.neighbor;
-                //assert(globJ != globI);
+                assert(globJ != globI);
                 res = 0.0;
                 bMat = 0.0;
                 adres = 0.0;
@@ -515,7 +515,7 @@ private:
             adres *= bdyInfo.bcdata.faceArea;
             setResAndJacobi(res, bMat, adres);
             residual_[globI] += res;
-            //jacobian_->addToBlock(globI, globI, bMat);
+            ////SparseAdapter syntax: jacobian_->addToBlock(globI, globI, bMat);
             *diagMatAddress_[globI] += bMat;
         }
     }

--- a/opm/simulators/linalg/istlsparsematrixadapter.hh
+++ b/opm/simulators/linalg/istlsparsematrixadapter.hh
@@ -155,6 +155,10 @@ public:
     void block(const size_t rowIdx, const size_t colIdx, MatrixBlock& value) const
     { value = (*istlMatrix_)[rowIdx][colIdx]; }
 
+    MatrixBlockType* blockAddress(const size_t rowIdx, const size_t colIdx) const
+    { return &(*istlMatrix_)[rowIdx][colIdx]; }
+
+        
     /*!
      * \brief Set matrix block to given block.
      */


### PR DESCRIPTION
Add direct access to matrix elements in tpfalinearizer. Seems to give a speedup of 10% for this part. off assembly. Together with not using local well assembly more speedup is seen.

Edit: By direct access to matrix elements, we mean that instead of using `m[row][col]` to access the matrix block to be modified (via the `addToBlock(row, col)` call), we store pointers to the relevant block. The `m[row][col]` requires a search on the relevant row to find the correct block matching the requested column number.