### PR TITLE
BUGFIX storage term for timeIdx 1 with DRSDT

### DIFF
--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -699,10 +699,10 @@ public:
             !intensiveQuantityCacheUpToDate_[timeIdx][globalIdx])
             return 0;
 
-        if (timeIdx > 0 && enableStorageCache_)
-            // with the storage cache enabled, only the intensive quantities for the most
-            // recent time step are cached!
-            return 0;
+        //if (timeIdx > 0 && enableStorageCache_)
+        //    // with the storage cache enabled, only the intensive quantities for the most
+        //    // recent time step are cached!
+        //    return 0;
 
         return &intensiveQuantityCache_[timeIdx][globalIdx];
     }
@@ -790,7 +790,7 @@ public:
         if (!storeIntensiveQuantities())
             return;
 
-        if (enableStorageCache()) {
+        if (false && enableStorageCache()) {
             // if the storage term is cached, the intensive quantities of the previous
             // time steps do not need to be accessed, and we can thus spare ourselves to
             // copy the objects for the intensive quantities.

--- a/opm/models/discretization/common/fvbaselocalresidual.hh
+++ b/opm/models/discretization/common/fvbaselocalresidual.hh
@@ -535,18 +535,12 @@ protected:
             if (elemCtx.enableStorageCache()) {
                 const auto& model = elemCtx.model();
                 unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
-                if (model.newtonMethod().numIterations() == 0 &&
-                    !elemCtx.haveStashedIntensiveQuantities())
-                {
-                    if (!elemCtx.problem().recycleFirstIterationStorage()) {
-                        // we re-calculate the storage term for the solution of the
-                        // previous time step from scratch instead of using the one of
-                        // the first iteration of the current time step.
-                        tmp2 = 0.0;
-                        elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/1);
-                        asImp_().computeStorage(tmp2, elemCtx,  dofIdx, /*timeIdx=*/1);
-                    }
-                    else {
+                for (unsigned eqIdx = 0; eqIdx < numEq; ++ eqIdx) {
+                    tmp2[eqIdx] = Toolbox::value(tmp[eqIdx]);
+                }
+                if(elemCtx.problem().recycleFirstIterationStorage()) {
+                    if (model.newtonMethod().numIterations() == 0)
+                    {
                         // if the storage term is cached and we're in the first iteration
                         // of the time step, use the storage term of the first iteration
                         // as the one as the solution of the last time step (this assumes
@@ -554,21 +548,17 @@ protected:
                         // step is the same as the solution at the beginning of the time
                         // step. This is usually true, but some fancy preprocessing
                         // scheme might invalidate that assumption.)
-                        for (unsigned eqIdx = 0; eqIdx < numEq; ++ eqIdx)
-                            tmp2[eqIdx] = Toolbox::value(tmp[eqIdx]);
+                        Valgrind::CheckDefined(tmp2);
+                        model.updateCachedStorage(globalDofIdx, /*timeIdx=*/1, tmp2);
                     }
-
-                    Valgrind::CheckDefined(tmp2);
-
-                    model.updateCachedStorage(globalDofIdx, /*timeIdx=*/1, tmp2);
+                } else {
+                    model.updateCachedStorage(globalDofIdx, /*timeIdx=*/0, tmp2);
                 }
-                else {
-                    // if the mass storage at the beginning of the time step is not cached,
-                    // if the storage term is cached and we're not looking at the first
-                    // iteration of the time step, we take the cached data.
-                    tmp2 = model.cachedStorage(globalDofIdx, /*timeIdx=*/1);
-                    Valgrind::CheckDefined(tmp2);
-                }
+                // if the storage term at the beginning of the time step is cached
+                // from the last time step or we're not looking at the first
+                // iteration of the time step, we take the cached data.
+                tmp2 = model.cachedStorage(globalDofIdx, /*timeIdx=*/1);
+                Valgrind::CheckDefined(tmp2);
             }
             else {
                 // if the mass storage at the beginning of the time step is not cached,

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -479,7 +479,14 @@ private:
             // TODO: check recycleFirst etc.
             // first we use it as storage cache
             if (model_().newtonMethod().numIterations() == 0) {
-                model_().updateCachedStorage(globI, /*timeIdx=*/1, res);
+                VectorBlock storage1(0.0);
+                const IntensiveQuantities* intQuantsInP1 = model_().cachedIntensiveQuantities(globI, /*timeIdx*/ 1);
+                if (intQuantsInP1 == nullptr) {
+                    throw std::logic_error("Missing updated intensive quantities for cell " + std::to_string(globI));
+                }
+                const IntensiveQuantities& intQuantsIn1 = (intQuantsInP1 == nullptr)? *intQuantsInP : *intQuantsInP1;
+                LocalResidual::computeStorage(storage1, intQuantsIn1);
+                model_().updateCachedStorage(globI, /*timeIdx=*/1, storage1);
             }
             res -= model_().cachedStorage(globI, 1);
             res *= storefac;


### PR DESCRIPTION
The bug was introduced with the new tpfa linarizer and effect all cases with DRSDT /DRSTCON/DRVDT 

I make it draft since it does not go well along with the current storageCache feature which seems to only be partly used by the new linearizer. 

Fixes issue reported in https://github.com/OPM/opm-simulators/issues/4318
