### PR TITLE
Add well source terms to the residual separately.

### DIFF
--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -562,6 +562,24 @@ public:
             source[Indices::contiEnergyEqIdx] *= getPropValue<TypeTag, Properties::BlackOilEnergyScalingFactor>();
     }
 
+    static void computeSourceDense(RateVector& source,
+                                   const Problem& problem,
+                                   unsigned globalSpaceIdex,
+                                   unsigned timeIdx)
+    {
+        source = 0.0;
+        problem.addToSourceDense(source, globalSpaceIdex, timeIdx);
+
+        // deal with MICP (if present)
+        // deal with micp (if present)
+        static_assert(!enableMICP, "Relevant addSource() method must be implemented for this module before enabling.");
+        // MICPModule::addSource(source, elemCtx, dofIdx, timeIdx);
+
+        // scale the source term of the energy equation
+        if (enableEnergy)
+            source[Indices::contiEnergyEqIdx] *= getPropValue<TypeTag, Properties::BlackOilEnergyScalingFactor>();
+    }
+
     /*!
      * \copydoc FvBaseLocalResidual::computeSource
      */

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -523,6 +523,7 @@ public:
         IntensiveQuantities::registerParameters();
         ExtensiveQuantities::registerParameters();
         NewtonMethod::registerParameters();
+        Linearizer::registerParameters();
 
         // register runtime parameters of the output modules
         VtkPrimaryVarsModule<TypeTag>::registerParameters();

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -532,11 +532,7 @@ public:
 private:
     void linearize_()
     {
-<<<<<<< HEAD
         OPM_TIMEBLOCK(linearize);
-        const bool well_local = true;
-=======
->>>>>>> 54ab7ee7c (add option to make well assembly based on only wells)
         resetSystem_();
         unsigned numCells = model_().numTotalDof();
         const bool& enableFlows = simulator_().problem().eclWriter()->eclOutputModule().hasFlows();
@@ -641,7 +637,7 @@ private:
 
         // Add sparse source terms. For now only wells.
         if (separateSparseSourceTerms_) {
-            problem_().wellModel().addReservoirSourceTerms(residual_, *jacobian_);
+            problem_().wellModel().addReservoirSourceTerms(residual_, diagMatAddress_);
         }
 
         // Boundary terms. Only looping over cells with nontrivial bcs.

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -55,7 +55,7 @@ namespace Opm::Properties {
     template<class TypeTag, class MyTypeTag>
     struct SeparateSparseSourceTerms {
         using type = bool;
-        static constexpr type value = true;
+        static constexpr type value = false;
     };
 }
 


### PR DESCRIPTION
The existing code adds the source terms cell by cell, and when a perforated cell is reached, all wells and perforations are iterated over to find the correct term to add. So with K total perforations, we do O(K^2) work. with the current PR, the well source terms will be treated separately, iterating over all wells and perforations just once, so O(K) work.

The difference for the assembly performance is modest: ~3% improvement observed (with SPE9, which has a fairly high number of wells for its size). But we see that there are more parts here that can be improved, building on this. We think similarly changing the approach for aquifers may give a similar boost for example.

We add a command line option `--separate-sparse-source-terms` to control the new feature (default is true, activating it). However, actually changing it is not available in the main "flow" executable at this point, since it was added in the TpfaLinearizer class, and the pre-TypeTag used for initial command line parsing uses the default linearizer. For the "flow_blackoil" executable, you can use the option to turn off the feature for comparisons. We may want to use the TpfaLinearizer for the pre-TypeTag, but that would add an option with no effect in the legacy assembly cases. Open to suggestions for the best approach here (or how to get rid of the TypeTag-dependency of the command line options).

There is a downstream branch in opm-simulators that must be combined with this.