### PR TITLE
Tag Potentially Unused Parameters as Maybe_Unused

### DIFF
--- a/opm/models/blackoil/blackoilboundaryratevector.hh
+++ b/opm/models/blackoil/blackoilboundaryratevector.hh
@@ -251,10 +251,10 @@ public:
      * conduction for energy.
      */
     template <class Context, class FluidState>
-    void setThermalFlow(const Context& context,
-                        unsigned bfIdx,
-                        unsigned timeIdx,
-                        const FluidState& boundaryFluidState)
+    void setThermalFlow([[maybe_unused]] const Context& context,
+                        [[maybe_unused]] unsigned bfIdx,
+                        [[maybe_unused]] unsigned timeIdx,
+                        [[maybe_unused]] const FluidState& boundaryFluidState)
     {
         // set the mass no-flow condition
         setNoFlow();


### PR DESCRIPTION
We don't reference any of the input parameters unless we're running a thermal simulation.