### PR TITLE
Modify Appleyard chopping

### DIFF
--- a/opm/models/blackoil/blackoilnewtonmethod.hh
+++ b/opm/models/blackoil/blackoilnewtonmethod.hh
@@ -307,7 +307,11 @@ protected:
             else if (pvIdx == Indices::waterSwitchIdx)
                 if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw)
                     delta *= satAlpha;
+
                 else {
+                    // The damping from the saturation change also applies to the rsw/rvw factors
+                    // for consistency
+                    delta *= satAlpha;
                     //Ensure Rvw and Rsw factor does not become negative
                     if (delta > currentValue[ Indices::waterSwitchIdx]) 
                         delta = currentValue[ Indices::waterSwitchIdx];
@@ -321,6 +325,9 @@ protected:
                 if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
                     delta *= satAlpha;
                 else {
+                    // The damping from the saturation change also applies to the rs/rv factors
+                    // for consistency
+                    delta *= satAlpha;
                     //Ensure Rv and Rs factor does not become negative
                     if (delta > currentValue[Indices::compositionSwitchIdx])
                         delta = currentValue[Indices::compositionSwitchIdx];
@@ -330,6 +337,7 @@ protected:
                 // solvent saturation updates are also subject to the Appleyard chop
                 delta *= satAlpha;
             else if (enableExtbo && pvIdx == Indices::zFractionIdx) {
+                delta *= satAlpha;
                 // z fraction updates are also subject to the Appleyard chop
                 if (delta > currentValue[Indices::zFractionIdx])
                         delta = currentValue[Indices::zFractionIdx];


### PR DESCRIPTION
Restrict update of rs/rv, rsw/rvw and zfraction in the extended blackoil model by the saturation scaling factor from the Appleyard-chopping.