### PR TITLE
Avoid collective operations in single-domain calls.

### DIFF
--- a/opm/models/blackoil/blackoilnewtonmethod.hh
+++ b/opm/models/blackoil/blackoilnewtonmethod.hh
@@ -239,33 +239,17 @@ public:
                  const GlobalEqVector& currentResidual,
                  const DofIndices& dofIndices)
     {
-        const auto& comm = this->simulator_.gridView().comm();
-
-        int succeeded;
-        try {
-            auto zero = solutionUpdate[0];
-            zero = 0.0;
-            for (auto dofIdx : dofIndices) {
-                if (solutionUpdate[dofIdx] == zero) {
-                    continue;
-                }
-                updatePrimaryVariables_(dofIdx,
-                                        nextSolution[dofIdx],
-                                        currentSolution[dofIdx],
-                                        solutionUpdate[dofIdx],
-                                        currentResidual[dofIdx]);
+        const auto zero = 0.0 * solutionUpdate[0];
+        for (auto dofIdx : dofIndices) {
+            if (solutionUpdate[dofIdx] == zero) {
+                continue;
             }
-            succeeded = 1;
+            updatePrimaryVariables_(dofIdx,
+                                    nextSolution[dofIdx],
+                                    currentSolution[dofIdx],
+                                    solutionUpdate[dofIdx],
+                                    currentResidual[dofIdx]);
         }
-        catch (...) {
-            succeeded = 0;
-        }
-        succeeded = comm.min(succeeded);
-
-        if (!succeeded)
-            throw NumericalProblem("A process did not succeed in adapting the primary variables");
-
-        numPriVarsSwitched_ = comm.sum(numPriVarsSwitched_);
     }
 
 protected:


### PR DESCRIPTION
This fix is necessary for using the NLDD method in MPI parallel runs. There are also fixes coming in opm-simulators but they are independent of this so it can be considered separately.

We must avoid collective operations (here: doing comm.sum() to detect exceptions on any process) in single-domain contexts, as those will not be synchronous across processes (similar to the situation for single-well contexts). Moving the logic to a different function preserves existing behaviour for regular Newton.