### PR TITLE
CLANG: Temporal fix to BC

### DIFF
--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -487,7 +487,7 @@ public:
     static void computeBoundaryFluxFree(const Problem& problem,
                                         RateVector& bdyFlux,
                                         const BoundaryConditionData& bdyInfo,
-                                        const IntensiveQuantities& insideIntQuants,
+                                        const IntensiveQuantities& insideIntQuantsHack,
                                         unsigned globalSpaceIdx)
     {
         OPM_TIMEBLOCK_LOCAL(computeBoundaryFluxFree);
@@ -495,6 +495,7 @@ public:
         std::array<short, numPhases> dnIdx;
         RateVector volumeFlux;
         RateVector pressureDifference;
+        const auto insideIntQuants = insideIntQuantsHack;
         ExtensiveQuantities::calculateBoundaryGradients_(problem,
                                                          globalSpaceIdx,
                                                          insideIntQuants,


### PR DESCRIPTION
After updating Xcode (15.0), when running a case with BC the simulation stops by:

``` 
Starting time step 0, stepsize 1 days, at day 0/73, date = 01-Jan-2025
Restart file written for report step 0/1, date = 01-Jan-2025 00:00:00
zsh: trace trap  /Users/dmar/Github/opm/build/opm-simulators/bin/flow_gasoil BC_FREE_TEST.DATA
```
It seems the insideIntQuants is modified after the function calculateBoundaryGradients_. This commit fixes that. I will look for a proper way to fix this, but if someone knows the solution, it will be very appreciated. 

[BC_FREE_TEST.DATA.zip](https://github.com/OPM/opm-models/files/12702188/BC_FREE_TEST.DATA.zip)
