### PR TITLE
removing NCPFlash header file in flashratevector

### DIFF
--- a/opm/models/flash/flashratevector.hh
+++ b/opm/models/flash/flashratevector.hh
@@ -31,7 +31,6 @@
 #include <dune/common/fvector.hh>
 
 #include <opm/models/common/energymodule.hh>
-#include <opm/material/constraintsolvers/NcpFlash.hpp>
 #include <opm/material/common/Valgrind.hpp>
 
 #include "flashintensivequantities.hh"

--- a/opm/models/flash/flashratevector.hh
+++ b/opm/models/flash/flashratevector.hh
@@ -33,7 +33,6 @@
 #include <opm/models/common/energymodule.hh>
 #include <opm/material/common/Valgrind.hpp>
 
-#include "flashintensivequantities.hh"
 
 namespace Opm {
 


### PR DESCRIPTION
it does not look like used.

removing it will make the class more generic in some way. 