### PR TITLE
fix issue when BCPROP is not set initially

### DIFF
--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -467,7 +467,9 @@ public:
                                     const IntensiveQuantities& insideIntQuants,
                                     unsigned globalSpaceIdx)
     {
-        if (bdyInfo.type == BCType::RATE) {
+        if (bdyInfo.type == BCType::NONE) {
+            bdyFlux = 0.0;
+        } else if (bdyInfo.type == BCType::RATE) {
             computeBoundaryFluxRate(bdyFlux, bdyInfo);
         } else if (bdyInfo.type == BCType::FREE || bdyInfo.type == BCType::DIRICHLET) {
             computeBoundaryFluxFree(problem, bdyFlux, bdyInfo, insideIntQuants, globalSpaceIdx);


### PR DESCRIPTION
In the current code BCPROP is ignored if it is not set in the first time step. This PR make it possible to set BCPROP later in the schedule. 