### PR TITLE
removing flashproperties.hh from multiple files

### DIFF
--- a/opm/models/flash/flashboundaryratevector.hh
+++ b/opm/models/flash/flashboundaryratevector.hh
@@ -28,8 +28,6 @@
 #ifndef EWOMS_FLASH_BOUNDARY_RATE_VECTOR_HH
 #define EWOMS_FLASH_BOUNDARY_RATE_VECTOR_HH
 
-#include "flashproperties.hh"
-
 #include <opm/models/common/energymodule.hh>
 #include <opm/material/common/Valgrind.hpp>
 

--- a/opm/models/flash/flashextensivequantities.hh
+++ b/opm/models/flash/flashextensivequantities.hh
@@ -28,8 +28,6 @@
 #ifndef EWOMS_FLASH_EXTENSIVE_QUANTITIES_HH
 #define EWOMS_FLASH_EXTENSIVE_QUANTITIES_HH
 
-#include "flashproperties.hh"
-
 #include <opm/models/common/multiphasebaseextensivequantities.hh>
 #include <opm/models/common/energymodule.hh>
 #include <opm/models/common/diffusionmodule.hh>

--- a/opm/models/flash/flashindices.hh
+++ b/opm/models/flash/flashindices.hh
@@ -28,7 +28,6 @@
 #ifndef EWOMS_FLASH_INDICES_HH
 #define EWOMS_FLASH_INDICES_HH
 
-#include "flashproperties.hh"
 #include <opm/models/common/energymodule.hh>
 
 namespace Opm {

--- a/opm/models/flash/flashlocalresidual.hh
+++ b/opm/models/flash/flashlocalresidual.hh
@@ -28,7 +28,6 @@
 #ifndef EWOMS_FLASH_LOCAL_RESIDUAL_HH
 #define EWOMS_FLASH_LOCAL_RESIDUAL_HH
 
-#include "flashproperties.hh"
 
 #include <opm/models/common/diffusionmodule.hh>
 #include <opm/models/common/energymodule.hh>

--- a/opm/models/flash/flashprimaryvariables.hh
+++ b/opm/models/flash/flashprimaryvariables.hh
@@ -29,7 +29,6 @@
 #define EWOMS_FLASH_PRIMARY_VARIABLES_HH
 
 #include "flashindices.hh"
-#include "flashproperties.hh"
 
 #include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
 #include <opm/models/common/energymodule.hh>


### PR DESCRIPTION
it does not looks like it is used.

At least, [flashboundaryratevector.hh](https://github.com/OPM/opm-models/compare/master...GitPaean:removing_flashproperties?expand=1#diff-46406dee878bf82a0f5e5ec542173608fc1c30fc7cd6a25c7e486b6c645601fd)  can reused by other flash solvers directly after removing this header files.  Others might need some adjustments before it can reused directly. 

There might be some design here, but they can be added back anytime when needed.  At least, with its current form, they are NOT used in anyway. 