### PR TITLE
Fix to write VTKS when THERMAL is on deck

### DIFF
--- a/opm/models/io/vtkblackoilenergymodule.hh
+++ b/opm/models/io/vtkblackoilenergymodule.hh
@@ -87,6 +87,7 @@ class VtkBlackOilEnergyModule : public BaseOutputModule<TypeTag>
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
     using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
 
     static const int vtkFormat = getPropValue<TypeTag, Properties::VtkOutputFormat>();
     using VtkMultiWriter = ::Opm::VtkMultiWriter<GridView, vtkFormat>;
@@ -172,13 +173,15 @@ public:
                     scalarValue(intQuants.totalThermalConductivity());
 
             for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
-                if (fluidInternalEnergiesOutput_())
-                    fluidInternalEnergies_[phaseIdx][globalDofIdx] =
-                        scalarValue(intQuants.fluidState().internalEnergy(phaseIdx));
+                if (FluidSystem::phaseIsActive(phaseIdx)) {
+                    if (fluidInternalEnergiesOutput_())
+                        fluidInternalEnergies_[phaseIdx][globalDofIdx] =
+                            scalarValue(intQuants.fluidState().internalEnergy(phaseIdx));
 
-                if (fluidEnthalpiesOutput_())
-                    fluidEnthalpies_[phaseIdx][globalDofIdx] =
-                        scalarValue(intQuants.fluidState().enthalpy(phaseIdx));
+                    if (fluidEnthalpiesOutput_())
+                        fluidEnthalpies_[phaseIdx][globalDofIdx] =
+                            scalarValue(intQuants.fluidState().enthalpy(phaseIdx));
+                }
             }
         }
     }


### PR DESCRIPTION
If the flag `--enable-vtk-output=true` is added to cases with `THERMAL` on the RUNSPEC section (e.g., [CO2STORE_ENERGY.DATA](https://github.com/OPM/opm-tests/blob/master/co2store/CO2STORE_ENERGY.DATA)), then the simulation throws 
```
Report step  0/2 at day 0/18250, date = 01-Jan-2025
Writing visualization results for the current time step.
Assertion failed: (phaseIsActive(phaseIdx)), function canonicalToActivePhaseIdx, file BlackOilFluidSystem.cpp, line 372.
```
This commit fixes this.