### PR TITLE
Depend on opm-common as a DUNE module

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -9,5 +9,5 @@ Description: OPM's numerical framework for flow and transport in porous media
 Url: http://opm-project.org
 MaintainerName: The Open Porous Media Project
 Maintainer: opm@opm-project.org
-Depends: dune-grid (>= 2.7) dune-istl  (>= 2.7)
+Depends: dune-grid (>= 2.7) dune-istl  (>= 2.7) opm-common
 Suggests: dune-localfunctions (>= 2.7) dune-fem  (>= 2.7) dune-alugrid (>= 2.7)  opm-grid


### PR DESCRIPTION
Backport of #840 
We do use a lot of headers from it and opm-grid (which also pulls it in is optional).