### PR TITLE
[fix] Skip manual error checking and rely on the error default handler aborting

### DIFF
--- a/opm/models/parallel/mpibuffer.hh
+++ b/opm/models/parallel/mpibuffer.hh
@@ -111,14 +111,19 @@ public:
     void receive([[maybe_unused]] unsigned peerRank)
     {
 #if HAVE_MPI
-        MPI_Recv(data_,
-                 static_cast<int>(mpiDataSize_),
-                 mpiDataType_,
-                 static_cast<int>(peerRank),
-                 0, // tag
-                 MPI_COMM_WORLD,
-                 &mpiStatus_);
-        assert(!mpiStatus_.MPI_ERROR);
+        // Use return code for error detection
+        // According to MPI standard the ERROR field
+        // might not be initialized unless for operations
+        // that return multiple statuses, see  Section 3.7.5
+        // of the standard
+        [[maybe_unused]] auto result = MPI_Recv(data_,
+                                                static_cast<int>(mpiDataSize_),
+                                                mpiDataType_,
+                                                static_cast<int>(peerRank),
+                                                0, // tag
+                                                MPI_COMM_WORLD,
+                                                MPI_STATUS_IGNORE);
+        assert(!result);
 #endif // HAVE_MPI
     }
 

--- a/opm/models/parallel/mpibuffer.hh
+++ b/opm/models/parallel/mpibuffer.hh
@@ -111,19 +111,13 @@ public:
     void receive([[maybe_unused]] unsigned peerRank)
     {
 #if HAVE_MPI
-        // Use return code for error detection
-        // According to MPI standard the ERROR field
-        // might not be initialized unless for operations
-        // that return multiple statuses, see  Section 3.7.5
-        // of the standard
-        [[maybe_unused]] auto result = MPI_Recv(data_,
-                                                static_cast<int>(mpiDataSize_),
-                                                mpiDataType_,
-                                                static_cast<int>(peerRank),
-                                                0, // tag
-                                                MPI_COMM_WORLD,
-                                                MPI_STATUS_IGNORE);
-        assert(!result);
+        MPI_Recv(data_,
+                 static_cast<int>(mpiDataSize_),
+                 mpiDataType_,
+                 static_cast<int>(peerRank),
+                 0, // tag
+                 MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
 #endif // HAVE_MPI
     }
 


### PR DESCRIPTION
According to MPI standard the ERROR field of MPI_Status might not be initialized unless for operations that return multiple statuses, see  Section 3.7.5 of the standard. In older OpenMPI versions (<=4.0.x) we were lucky that ERROR was initialized to 0 always. This is not the case for 4.1.y at least. See open-mpi/ompi#12049.

Therefore we skip the additional manual that has no effect with the default error handler and rely on the error handler aborting the program.

Fixed running the tests on Debian bookworm