### PR TITLE
Compositional: 1D example for validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ foreach(tapp co2injection_flash_ni_vcfv
              co2injection_ncp_ni_ecfv
              co2injection_pvs_ni_ecfv
              co2_ptflash_ecfv
+             co2_ptflash_ecfv_validation
              powerinjection_forchheimer_fd
              powerinjection_forchheimer_ad
              powerinjection_darcy_fd

--- a/tests/co2_ptflash_ecfv_validation.cc
+++ b/tests/co2_ptflash_ecfv_validation.cc
@@ -1,0 +1,62 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Box problem with two phases and multiple components.
+ *        Solved with a PTFlash two phase solver.
+ */
+#include "config.h"
+
+#include <opm/models/utils/start.hh>
+#include "problems/co2ptflashproblemvalidation.hh"
+
+
+namespace Opm::Properties {
+
+namespace TTag {
+    struct CO2PTEcfvProblemValidation {
+    using InheritsFrom = std::tuple<CO2PTBaseProblem, FlashModel>;
+};
+}
+
+template <class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::CO2PTEcfvProblemValidation>
+{
+    using type = TTag::EcfvDiscretization;
+};
+
+template <class TypeTag>
+struct LocalLinearizerSplice<TypeTag, TTag::CO2PTEcfvProblemValidation>
+{
+    using type = TTag::AutoDiffLocalLinearizer;
+};
+
+
+} // namespace Opm::Properties
+
+int main(int argc, char **argv)
+{
+    using EcfvProblemTypeTag = Opm::Properties::TTag::CO2PTEcfvProblemValidation;
+    return Opm::start<EcfvProblemTypeTag>(argc, argv);
+}


### PR DESCRIPTION
Draft for discussion. This adds an example that can be matched against other simulators. Example uses non-equilibrium initial conditions to simulate a CO2 displacement. Depends on PR in opm-common: https://github.com/OPM/opm-common/pull/3846

![image (19)](https://github.com/OPM/opm-models/assets/454871/1d677368-820a-45b1-a3aa-1193172b4c3d)
