### PR TITLE
Support for dynamic scaling of capillary pressure due to salt precipitation

### DIFF
--- a/opm/models/blackoil/blackoilbrineparams.hh
+++ b/opm/models/blackoil/blackoilbrineparams.hh
@@ -40,6 +40,7 @@ struct BlackOilBrineParams {
     using TabulatedFunction = Tabulated1DFunction<Scalar>;
 
     std::vector<TabulatedFunction> bdensityTable_;
+    std::vector<TabulatedFunction> pcfactTable_;
     std::vector<TabulatedFunction> permfactTable_;
     std::vector<Scalar> saltsolTable_;
     std::vector<Scalar> saltdenTable_;

--- a/opm/models/blackoil/blackoilproblem.hh
+++ b/opm/models/blackoil/blackoilproblem.hh
@@ -102,6 +102,9 @@ public:
                                unsigned,
                                unsigned) const
     { return 0; }
+    
+    Scalar satnumRegionIndex(unsigned) const
+    { return 0; }
 
     /*!
      * \brief Returns the index of the relevant region for solvent mixing functions


### PR DESCRIPTION
With https://github.com/OPM/opm-common/pull/3857, this PR adds support for dynamically scaling the capillary pressure as a result of porosity changes in salt precipitation. This is achieved by adding a multiplier using tables, as it is done for the permeability reduction (while the pcfact tables are set for each satnum region, the current implementation of permfact is defined via the pvtnum regions; this PR could changed that to satnum as well if it is of interest). An example of this functionality can be found in https://github.com/OPM/opm-tests/pull/1117. The Figure on the left corresponds to the resulting PC surface for that example and on the right the comparison for the salt precipitation in the bottom cell with and without this feature. 
<img width="924" alt="SALTPREC_PCFACT" src="https://github.com/OPM/opm-models/assets/61784809/3924cc0b-9b37-4f1a-b32d-2668b94d8be2">
