### PR TITLE
[bugfix] Do not try to save FLOWS or FLOWRES values for NNCs.

### DIFF
--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -665,6 +665,9 @@ public:
             OPM_TIMEBLOCK_LOCAL(fluxCalculationForEachCell);
             for (const auto& nbInfo : nbInfos) {
                 OPM_TIMEBLOCK_LOCAL(fluxCalculationForEachFace);
+                // not for NNCs
+                if (nbInfo.res_nbinfo.dirId < 0)
+                    continue;
                 unsigned globJ = nbInfo.neighbor;
                 assert(globJ != globI);
                 adres = 0.0;


### PR DESCRIPTION
If we would try that then we would index vectors with index -1 and possibly overwrite other system information. This was the case for some models resulting in cryptic errror " corrupted size vs. prev_size"

Now we simply do nothing for NNCs.