### PR TITLE
Avoid deleting derivatives with zero pressure difference

### DIFF
--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -374,15 +374,13 @@ public:
             // Use arithmetic average (more accurate with harmonic, but that requires recomputing the transmissbility)
             const Evaluation transMult = (intQuantsIn.rockCompTransMultiplier() + Toolbox::value(intQuantsEx.rockCompTransMultiplier()))/2;
             Evaluation darcyFlux;
-            if (pressureDifference == 0) {
-                darcyFlux = 0.0; // NB maybe we could drop calculations
-            } else {
-                if (globalUpIndex == globalIndexIn)
+            if (globalUpIndex == globalIndexIn) {
                     darcyFlux = pressureDifference * up.mobility(phaseIdx, facedir) * transMult * (-trans / faceArea);
-                else
-                    darcyFlux = pressureDifference *
-                       (Toolbox::value(up.mobility(phaseIdx, facedir)) * transMult * (-trans / faceArea));
+            } else {
+                darcyFlux = pressureDifference *
+                    (Toolbox::value(up.mobility(phaseIdx, facedir)) * transMult * (-trans / faceArea));
             }
+
             unsigned activeCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(phaseIdx));
             darcy[conti0EqIdx + activeCompIdx] = darcyFlux.value() * faceArea; // NB! For the FLORES fluxes without derivatives
 


### PR DESCRIPTION
* avoid getting zero in matrix in zero pressure/zero flux case
* may make it easier to have lower/upper limits on pressures

This should be the correct, but it will may change many tests so it should be investigated carefully.