### PR TITLE
Fix cmake warning with line order change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,10 @@
 #                                                                         #
 ###########################################################################
 
+cmake_minimum_required (VERSION 3.10)
+
 # Mandatory call to project
 project(opm-models C CXX)
-
-cmake_minimum_required (VERSION 3.10)
 
 # add the current projects cmake module directory to the search
 # path. This is not required anymore once support for federated builds


### PR DESCRIPTION
Change line order to remove this warning:

> CMake Warning (dev) at CMakeLists.txt:16 (project):
>   cmake_minimum_required() should be called prior to this top-level project()
>   call.  Please see the cmake-commands(7) manual for usage documentation of
>   both commands.
> This warning is for project developers.  Use -Wno-dev to suppress it.