### PR TITLE
changing including guard name for two diffusionmodule

### DIFF
--- a/opm/models/blackoil/blackoildiffusionmodule.hh
+++ b/opm/models/blackoil/blackoildiffusionmodule.hh
@@ -25,8 +25,8 @@
  *
  * \brief Classes required for molecular diffusion.
  */
-#ifndef EWOMS_DIFFUSION_MODULE_HH
-#define EWOMS_DIFFUSION_MODULE_HH
+#ifndef OPM_BLACKOIL_DIFFUSION_MODULE_HH
+#define OPM_BLACKOIL_DIFFUSION_MODULE_HH
 
 #include <opm/models/discretization/common/fvbaseproperties.hh>
 

--- a/opm/models/common/diffusionmodule.hh
+++ b/opm/models/common/diffusionmodule.hh
@@ -25,8 +25,8 @@
  *
  * \brief Classes required for molecular diffusion.
  */
-#ifndef EWOMS_DIFFUSION_MODULE_HH
-#define EWOMS_DIFFUSION_MODULE_HH
+#ifndef OPM_DIFFUSION_MODULE_HH
+#define OPM_DIFFUSION_MODULE_HH
 
 #include <opm/models/discretization/common/fvbaseproperties.hh>
 #include <opm/models/common/quantitycallbacks.hh>


### PR DESCRIPTION
they used to use the same EWOMS_DIFFUSION_MODULE_HH

It looks like `#pragma once` might be better when coming to this. 