### PR TITLE
Remove unused EWOMS_RESET_PARAMS macro

### DIFF
--- a/opm/models/utils/parametersystem.hh
+++ b/opm/models/utils/parametersystem.hh
@@ -132,10 +132,6 @@
 #define EWOMS_GET_PARAM_LISTS(TypeTag, UsedParamList, UnusedParamList)    \
     (::Opm::Parameters::getLists<TypeTag>(UsedParamList, UnusedParamList))
 
-//!\cond SKIP_THIS
-#define EWOMS_RESET_PARAMS_(TypeTag)            \
-    (::Opm::Parameters::reset<TypeTag>())
-
 /*!
  * \ingroup Parameter
  *

--- a/opm/models/utils/parametersystem.hh
+++ b/opm/models/utils/parametersystem.hh
@@ -29,8 +29,8 @@
  * Dune::ParameterTree with the default value taken from the property
  * system.
  */
-#ifndef EWOMS_PARAMETER_SYSTEM_HH
-#define EWOMS_PARAMETER_SYSTEM_HH
+#ifndef OPM_PARAMETER_SYSTEM_HH
+#define OPM_PARAMETER_SYSTEM_HH
 
 #include <opm/models/utils/propertysystem.hh>
 
@@ -1226,4 +1226,4 @@ void endParamRegistration()
 } // namespace Parameters
 } // namespace Opm
 
-#endif
+#endif // OPM_PARAMETER_SYSTEM_HH


### PR DESCRIPTION
This macro is unused, it adds no convenience in any case and less macros is always good.