### PR TITLE
Remove ewoms register param macro

### DIFF
--- a/opm/models/blackoil/blackoilnewtonmethod.hh
+++ b/opm/models/blackoil/blackoilnewtonmethod.hh
@@ -186,18 +186,29 @@ public:
     {
         ParentType::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, DpMaxRel, "Maximum relative change of pressure in a single iteration");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, DsMax, "Maximum absolute change of any saturation in a single iteration");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, PriVarOscilationThreshold,
-                             "The threshold value for the primary variable switching conditions after its meaning has switched to hinder oscilations");
-        EWOMS_REGISTER_PARAM(TypeTag,bool, ProjectSaturations, "Option for doing saturation projection");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaxTemperatureChange, "Maximum absolute change of temperature in a single iteration");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, TemperatureMax, "Maximum absolute temperature");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, TemperatureMin, "Minimum absolute temperature");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, PressureMax, "Maximum absolute pressure");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, PressureMin, "Minimum absolute pressure");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaximumWaterSaturation, "Maximum water saturation");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, WaterOnlyThreshold, "Cells with water saturation above or equal is considered one-phase water only");
+        Parameters::registerParam<TypeTag, Properties::DpMaxRel>
+            ("Maximum relative change of pressure in a single iteration");
+        Parameters::registerParam<TypeTag, Properties::DsMax>
+            ("Maximum absolute change of any saturation in a single iteration");
+        Parameters::registerParam<TypeTag, Properties::PriVarOscilationThreshold>
+            ("The threshold value for the primary variable switching conditions "
+             "after its meaning has switched to hinder oscilations");
+        Parameters::registerParam<TypeTag, Properties::ProjectSaturations>
+            ("Option for doing saturation projection");
+        Parameters::registerParam<TypeTag, Properties::MaxTemperatureChange>
+            ("Maximum absolute change of temperature in a single iteration");
+        Parameters::registerParam<TypeTag, Properties::TemperatureMax>
+            ("Maximum absolute temperature");
+        Parameters::registerParam<TypeTag, Properties::TemperatureMin>
+            ("Minimum absolute temperature");
+        Parameters::registerParam<TypeTag, Properties::PressureMax>
+            ("Maximum absolute pressure");
+        Parameters::registerParam<TypeTag, Properties::PressureMin>
+            ("Minimum absolute pressure");
+        Parameters::registerParam<TypeTag, Properties::MaximumWaterSaturation>
+            ("Maximum water saturation");
+        Parameters::registerParam<TypeTag, Properties::WaterOnlyThreshold>
+            ("Cells with water saturation above or equal is considered one-phase water only");
     }
 
     /*!

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -217,7 +217,8 @@ public:
 
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, double, PressureScale, "Scaling of pressure primary variable");
+        Parameters::registerParam<TypeTag, Properties::PressureScale>
+            ("Scaling of pressure primary variable");
     }
 
     void setPressureScale(Scalar val)

--- a/opm/models/common/multiphasebaseproblem.hh
+++ b/opm/models/common/multiphasebaseproblem.hh
@@ -90,8 +90,8 @@ public:
     {
         ParentType::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableGravity,
-                             "Use the gravity correction for the pressure gradients.");
+        Parameters::registerParam<TypeTag, Properties::EnableGravity>
+            ("Use the gravity correction for the pressure gradients.");
     }
 
     /*!

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -510,12 +510,18 @@ public:
         // register runtime parameters of the output modules
         VtkPrimaryVarsModule<TypeTag>::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableGridAdaptation, "Enable adaptive grid refinement/coarsening");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableVtkOutput, "Global switch for turning on writing VTK files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableThermodynamicHints, "Enable thermodynamic hints");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableIntensiveQuantityCache, "Turn on caching of intensive quantities");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableStorageCache, "Store previous storage terms and avoid re-calculating them.");
-        EWOMS_REGISTER_PARAM(TypeTag, std::string, OutputDir, "The directory to which result files are written");
+        Parameters::registerParam<TypeTag, Properties::EnableGridAdaptation>
+            ("Enable adaptive grid refinement/coarsening");
+        Parameters::registerParam<TypeTag, Properties::EnableVtkOutput>
+            ("Global switch for turning on writing VTK files");
+        Parameters::registerParam<TypeTag, Properties::EnableThermodynamicHints>
+            ("Enable thermodynamic hints");
+        Parameters::registerParam<TypeTag, Properties::EnableIntensiveQuantityCache>
+            ("Turn on caching of intensive quantities");
+        Parameters::registerParam<TypeTag, Properties::EnableStorageCache>
+            ("Store previous storage terms and avoid re-calculating them.");
+        Parameters::registerParam<TypeTag, Properties::OutputDir>
+            ("The directory to which result files are written");
     }
 
     /*!

--- a/opm/models/discretization/common/fvbasefdlocallinearizer.hh
+++ b/opm/models/discretization/common/fvbasefdlocallinearizer.hh
@@ -182,9 +182,9 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, int, NumericDifferenceMethod,
-                             "The method used for numeric differentiation (-1: backward "
-                             "differences, 0: central differences, 1: forward differences)");
+        Parameters::registerParam<TypeTag, Properties::NumericDifferenceMethod>
+            ("The method used for numeric differentiation (-1: backward "
+             "differences, 0: central differences, 1: forward differences)");
     }
 
     /*!

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -168,19 +168,19 @@ public:
     static void registerParameters()
     {
         Model::registerParameters();
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaxTimeStepSize,
-                             "The maximum size to which all time steps are limited to [s]");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, MinTimeStepSize,
-                             "The minimum size to which all time steps are limited to [s]");
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, MaxTimeStepDivisions,
-                             "The maximum number of divisions by two of the timestep size "
-                             "before the simulation bails out");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableAsyncVtkOutput,
-                             "Dispatch a separate thread to write the VTK output");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, ContinueOnConvergenceError,
-                             "Continue with a non-converged solution instead of giving up "
-                             "if we encounter a time step size smaller than the minimum time "
-                             "step size.");
+        Parameters::registerParam<TypeTag, Properties::MaxTimeStepSize>
+            ("The maximum size to which all time steps are limited to [s]");
+        Parameters::registerParam<TypeTag, Properties::MinTimeStepSize>
+            ("The minimum size to which all time steps are limited to [s]");
+        Parameters::registerParam<TypeTag, Properties::MaxTimeStepDivisions>
+            ("The maximum number of divisions by two of the timestep size "
+             "before the simulation bails out");
+        Parameters::registerParam<TypeTag, Properties::EnableAsyncVtkOutput>
+            ("Dispatch a separate thread to write the VTK output");
+        Parameters::registerParam<TypeTag, Properties::ContinueOnConvergenceError>
+            ("Continue with a non-converged solution instead of giving up "
+             "if we encounter a time step size smaller than the minimum time "
+             "step size.");
     }
 
     /*!

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -134,8 +134,8 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, SeparateSparseSourceTerms,
-                             "Treat well source terms all in one go, instead of on a cell by cell basis.");
+        Parameters::registerParam<TypeTag, Properties::SeparateSparseSourceTerms>
+            ("Treat well source terms all in one go, instead of on a cell by cell basis.");
     }
 
     /*!

--- a/opm/models/flash/flashmodel.hh
+++ b/opm/models/flash/flashmodel.hh
@@ -234,9 +234,9 @@ public:
         if (enableEnergy)
             Opm::VtkEnergyModule<TypeTag>::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, FlashTolerance,
-                             "The maximum tolerance for the flash solver to "
-                             "consider the solution converged");
+        Parameters::registerParam<TypeTag, Properties::FlashTolerance>
+            ("The maximum tolerance for the flash solver to "
+             "consider the solution converged");
     }
 
     /*!

--- a/opm/models/io/cubegridvanguard.hh
+++ b/opm/models/io/cubegridvanguard.hh
@@ -66,24 +66,24 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, GridGlobalRefinements,
-                             "The number of global refinements of the grid "
-                             "executed after it was loaded");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, DomainSizeX,
-                             "The size of the domain in x direction");
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, CellsX,
-                             "The number of intervalls in x direction");
+        Parameters::registerParam<TypeTag, Properties::GridGlobalRefinements>
+            ("The number of global refinements of the grid "
+             "executed after it was loaded");
+        Parameters::registerParam<TypeTag, Properties::DomainSizeX>
+            ("The size of the domain in x direction");
+        Parameters::registerParam<TypeTag, Properties::CellsX>
+            ("The number of intervalls in x direction");
         if (dimWorld > 1) {
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, DomainSizeY,
-                                 "The size of the domain in y direction");
-            EWOMS_REGISTER_PARAM(TypeTag, unsigned, CellsY,
-                                 "The number of intervalls in y direction");
+            Parameters::registerParam<TypeTag, Properties::DomainSizeY>
+                ("The size of the domain in y direction");
+            Parameters::registerParam<TypeTag, Properties::CellsY>
+                ("The number of intervalls in y direction");
         }
         if (dimWorld > 2) {
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, DomainSizeZ,
-                                 "The size of the domain in z direction");
-            EWOMS_REGISTER_PARAM(TypeTag, unsigned, CellsZ,
-                                 "The number of intervalls in z direction");
+            Parameters::registerParam<TypeTag, Properties::DomainSizeZ>
+                ("The size of the domain in z direction");
+            Parameters::registerParam<TypeTag, Properties::CellsZ>
+                ("The number of intervalls in z direction");
         }
     }
 

--- a/opm/models/io/dgfvanguard.hh
+++ b/opm/models/io/dgfvanguard.hh
@@ -62,11 +62,11 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, std::string, GridFile,
-                             "The file name of the DGF file to load");
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, GridGlobalRefinements,
-                             "The number of global refinements of the grid "
-                             "executed after it was loaded");
+        Parameters::registerParam<TypeTag,Properties::GridFile>
+            ("The file name of the DGF file to load");
+        Parameters::registerParam<TypeTag,Properties::GridGlobalRefinements>
+            ("The number of global refinements of the grid "
+             "executed after it was loaded");
     }
 
     /*!

--- a/opm/models/io/structuredgridvanguard.hh
+++ b/opm/models/io/structuredgridvanguard.hh
@@ -106,24 +106,24 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, GridGlobalRefinements,
-                             "The number of global refinements of the grid "
-                             "executed after it was loaded");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, DomainSizeX,
-                             "The size of the domain in x direction");
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, CellsX,
-                             "The number of intervalls in x direction");
+        Parameters::registerParam<TypeTag, Properties::GridGlobalRefinements>
+            ("The number of global refinements of the grid "
+             "executed after it was loaded");
+        Parameters::registerParam<TypeTag, Properties::DomainSizeX>
+            ("The size of the domain in x direction");
+        Parameters::registerParam<TypeTag, Properties::CellsX>
+            ("The number of intervalls in x direction");
         if (dim > 1) {
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, DomainSizeY,
-                                 "The size of the domain in y direction");
-            EWOMS_REGISTER_PARAM(TypeTag, unsigned, CellsY,
-                                 "The number of intervalls in y direction");
+            Parameters::registerParam<TypeTag, Properties::DomainSizeY>
+                ("The size of the domain in y direction");
+            Parameters::registerParam<TypeTag, Properties::CellsY>
+                ("The number of intervalls in y direction");
         }
         if (dim > 2) {
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, DomainSizeZ,
-                                 "The size of the domain in z direction");
-            EWOMS_REGISTER_PARAM(TypeTag, unsigned, CellsZ,
-                                 "The number of intervalls in z direction");
+            Parameters::registerParam<TypeTag, Properties::DomainSizeZ>
+                ("The size of the domain in z direction");
+            Parameters::registerParam<TypeTag, Properties::CellsZ>
+                ("The number of intervalls in z direction");
         }
     }
 

--- a/opm/models/io/vtkblackoilenergymodule.hh
+++ b/opm/models/io/vtkblackoilenergymodule.hh
@@ -112,18 +112,16 @@ public:
         if (!enableEnergy)
             return;
 
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteRockInternalEnergy,
-                             "Include the volumetric internal energy of rock "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteTotalThermalConductivity,
-                             "Include the total thermal conductivity of the medium and the fluids "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFluidInternalEnergies,
-                             "Include the internal energies of the fluids "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFluidEnthalpies,
-                             "Include the enthalpies of the fluids "
-                             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteRockInternalEnergy>
+            ("Include the volumetric internal energy of rock "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteTotalThermalConductivity>
+            ("Include the total thermal conductivity of the medium and the fluids "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFluidInternalEnergies>
+            ("Include the internal energies of the fluids in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFluidEnthalpies>
+            ("Include the enthalpies of the fluids in the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkblackoilmicpmodule.hh
+++ b/opm/models/io/vtkblackoilmicpmodule.hh
@@ -113,21 +113,19 @@ public:
         if (!enableMICP)
             return;
 
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteMicrobialConcentration,
-                             "Include the concentration of the microbial component in the water phase "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteOxygenConcentration,
-                             "Include the concentration of the oxygen component in the water phase "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteUreaConcentration,
-                             "Include the concentration of the urea component in the water phase "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteBiofilmConcentration,
-                             "Include the biofilm volume fraction "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteCalciteConcentration,
-                             "Include the calcite volume fraction "
-                             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteMicrobialConcentration>
+            ("Include the concentration of the microbial component in the water phase "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteOxygenConcentration>
+            ("Include the concentration of the oxygen component in the water phase "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteUreaConcentration>
+            ("Include the concentration of the urea component in the water phase "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteBiofilmConcentration>
+            ("Include the biofilm volume fraction in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteCalciteConcentration>
+            ("Include the calcite volume fraction in the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkblackoilmodule.hh
+++ b/opm/models/io/vtkblackoilmodule.hh
@@ -141,39 +141,38 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteGasDissolutionFactor,
-                             "Include the gas dissolution factor (R_s) of the observed oil "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteOilVaporizationFactor,
-                             "Include the oil vaporization factor (R_v) of the observed gas "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteOilFormationVolumeFactor,
-                             "Include the oil formation volume factor (B_o) in the "
-                             "VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteGasFormationVolumeFactor,
-                             "Include the gas formation volume factor (B_g) in the "
-                             "VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteWaterFormationVolumeFactor,
-                             "Include the water formation volume factor (B_w) in the "
-                             "VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteOilSaturationPressure,
-                             "Include the saturation pressure of oil (p_o,sat) in the "
-                             "VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteGasSaturationPressure,
-                             "Include the saturation pressure of gas (p_g,sat) in the "
-                             "VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSaturatedOilGasDissolutionFactor,
-                             "Include the gas dissolution factor (R_s,sat) of gas saturated "
-                             "oil in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSaturatedGasOilVaporizationFactor,
-                             "Include the oil vaporization factor (R_v,sat) of oil saturated "
-                             "gas in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSaturationRatios,
-                             "Write the ratio of the actually and maximum dissolved component of "
-                             "the mixtures");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePrimaryVarsMeaning,
-                             "Include how the primary variables should be interpreted to the "
-                             "VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteGasDissolutionFactor>
+            ("Include the gas dissolution factor (R_s) of the observed oil "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteOilVaporizationFactor>
+            ("Include the oil vaporization factor (R_v) of the observed gas "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteOilFormationVolumeFactor>
+            ("Include the oil formation volume factor (B_o) in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteGasFormationVolumeFactor>
+            ("Include the gas formation volume factor (B_g) in the "
+             "VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteWaterFormationVolumeFactor>
+            ("Include the water formation volume factor (B_w) in the "
+             "VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteOilSaturationPressure>
+            ("Include the saturation pressure of oil (p_o,sat) in the "
+             "VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteGasSaturationPressure>
+            ("Include the saturation pressure of gas (p_g,sat) in the "
+             "VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteSaturatedOilGasDissolutionFactor>
+            ("Include the gas dissolution factor (R_s,sat) of gas saturated "
+             "oil in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteSaturatedGasOilVaporizationFactor>
+            ("Include the oil vaporization factor (R_v,sat) of oil saturated "
+             "gas in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteSaturationRatios>
+            ("Write the ratio of the actually and maximum dissolved component of "
+             "the mixtures");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePrimaryVarsMeaning>
+            ("Include how the primary variables should be interpreted to the "
+             "VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkblackoilpolymermodule.hh
+++ b/opm/models/io/vtkblackoilpolymermodule.hh
@@ -117,24 +117,24 @@ public:
         if (!enablePolymer)
             return;
 
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerConcentration,
-                             "Include the concentration of the polymer component in the water phase "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerDeadPoreVolume,
-                             "Include the fraction of the \"dead\" pore volume "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerRockDensity,
-                             "Include the amount of already adsorbed polymer component"
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerAdsorption,
-                             "Include the adsorption rate of the polymer component"
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerViscosityCorrection,
-                             "Include the viscosity correction of the polymer component "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteWaterViscosityCorrection,
-                             "Include the viscosity correction of the water component "
-                             "due to polymers in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePolymerConcentration>
+            ("Include the concentration of the polymer component in the water phase "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePolymerDeadPoreVolume>
+            ("Include the fraction of the \"dead\" pore volume "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePolymerRockDensity>
+            ("Include the amount of already adsorbed polymer component"
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePolymerAdsorption>
+            ("Include the adsorption rate of the polymer component"
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePolymerViscosityCorrection>
+            ("Include the viscosity correction of the polymer component "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteWaterViscosityCorrection>
+            ("Include the viscosity correction of the water component "
+             "due to polymers in the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkblackoilsolventmodule.hh
+++ b/opm/models/io/vtkblackoilsolventmodule.hh
@@ -113,21 +113,21 @@ public:
         if (!enableSolvent)
             return;
 
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSolventSaturation,
-                             "Include the \"saturation\" of the solvent component "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSolventRsw,
-                             "Include the \"dissolved volume in water\" of the solvent component "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSolventDensity,
-                             "Include the \"density\" of the solvent component "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSolventViscosity,
-                             "Include the \"viscosity\" of the solvent component "
-                             "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSolventMobility,
-                             "Include the \"mobility\" of the solvent component "
-                             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteSolventSaturation>
+            ("Include the \"saturation\" of the solvent component "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteSolventRsw>
+            ("Include the \"dissolved volume in water\" of the solvent component "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteSolventDensity>
+            ("Include the \"density\" of the solvent component "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteSolventViscosity>
+            ("Include the \"viscosity\" of the solvent component "
+             "in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteSolventMobility>
+            ("Include the \"mobility\" of the solvent component "
+             "in the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkcompositionmodule.hh
+++ b/opm/models/io/vtkcompositionmodule.hh
@@ -123,20 +123,20 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteMassFractions,
-                             "Include mass fractions in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteMoleFractions,
-                             "Include mole fractions in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteTotalMassFractions,
-                             "Include total mass fractions in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteTotalMoleFractions,
-                             "Include total mole fractions in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteMolarities,
-                             "Include component molarities in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFugacities,
-                             "Include component fugacities in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFugacityCoeffs,
-                             "Include component fugacity coefficients in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteMassFractions>
+            ("Include mass fractions in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteMoleFractions>
+            ("Include mole fractions in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteTotalMassFractions>
+            ("Include total mass fractions in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteTotalMoleFractions>
+            ("Include total mole fractions in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteMolarities>
+            ("Include component molarities in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFugacities>
+            ("Include component fugacities in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFugacityCoeffs>
+            ("Include component fugacity coefficients in the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkdiffusionmodule.hh
+++ b/opm/models/io/vtkdiffusionmodule.hh
@@ -108,16 +108,14 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteTortuosities,
-                             "Include the tortuosity for each phase in the VTK "
-                             "output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteDiffusionCoefficients,
-                             "Include the molecular diffusion coefficients in "
-                             "the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool,
-                             VtkWriteEffectiveDiffusionCoefficients,
-                             "Include the effective molecular diffusion "
-                             "coefficients the medium in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteTortuosities>
+            ("Include the tortuosity for each phase in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteDiffusionCoefficients>
+            ("Include the molecular diffusion coefficients in "
+             "the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteEffectiveDiffusionCoefficients>
+            ("Include the effective molecular diffusion "
+             "coefficients the medium in the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkdiscretefracturemodule.hh
+++ b/opm/models/io/vtkdiscretefracturemodule.hh
@@ -133,23 +133,22 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFractureSaturations,
-                             "Include the phase saturations in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFractureMobilities,
-                             "Include the phase mobilities in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFractureRelativePermeabilities,
-                             "Include the phase relative permeabilities in the "
-                             "VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFracturePorosity,
-                             "Include the porosity in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFractureIntrinsicPermeabilities,
-                             "Include the intrinsic permeability in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFractureFilterVelocities,
-                             "Include in the filter velocities of the phases "
-                             "the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFractureVolumeFraction,
-                             "Add the fraction of the total volume which is "
-                             "occupied by fractures in the VTK output");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFractureSaturations>
+            ("Include the phase saturations in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFractureMobilities>
+            ("Include the phase mobilities in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFractureRelativePermeabilities>
+            ("Include the phase relative permeabilities in the "
+             "VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFracturePorosity>
+            ("Include the porosity in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFractureIntrinsicPermeabilities>
+            ("Include the intrinsic permeability in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFractureFilterVelocities>
+            ("Include in the filter velocities of the phases in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFractureVolumeFraction>
+            ("Add the fraction of the total volume which is "
+             "occupied by fractures in the VTK output");
     }
 
     /*!

--- a/opm/models/io/vtkenergymodule.hh
+++ b/opm/models/io/vtkenergymodule.hh
@@ -111,18 +111,18 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSolidInternalEnergy,
-                             "Include the volumetric internal energy of solid"
-                             "matrix in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteThermalConductivity,
-                             "Include the total thermal conductivity of the"
-                             "medium in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteEnthalpies,
-                             "Include the specific enthalpy of the phases in "
-                             "the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteInternalEnergies,
-                             "Include the specific internal energy of the "
-                             "phases in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteSolidInternalEnergy>
+            ("Include the volumetric internal energy of solid"
+             "matrix in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteThermalConductivity>
+            ("Include the total thermal conductivity of the"
+             "medium in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteEnthalpies>
+            ("Include the specific enthalpy of the phases in "
+             "the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteInternalEnergies>
+            ("Include the specific internal energy of the "
+             "phases in the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkmultiphasemodule.hh
+++ b/opm/models/io/vtkmultiphasemodule.hh
@@ -162,30 +162,30 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteExtrusionFactor,
-                             "Include the extrusion factor of the degrees of freedom into the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePressures,
-                             "Include the phase pressures in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteDensities,
-                             "Include the phase densities in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSaturations,
-                             "Include the phase saturations in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteMobilities,
-                             "Include the phase mobilities in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteRelativePermeabilities,
-                             "Include the phase relative permeabilities in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteViscosities,
-                             "Include component phase viscosities in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteAverageMolarMasses,
-                             "Include the average phase mass in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePorosity,
-                             "Include the porosity in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteIntrinsicPermeabilities,
-                             "Include the intrinsic permeability in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFilterVelocities,
-                             "Include in the filter velocities of the phases the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePotentialGradients,
-                             "Include the phase pressure potential gradients in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteExtrusionFactor>
+            ("Include the extrusion factor of the degrees of freedom into the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePressures>
+            ("Include the phase pressures in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteDensities>
+            ("Include the phase densities in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteSaturations>
+            ("Include the phase saturations in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteMobilities>
+            ("Include the phase mobilities in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteRelativePermeabilities>
+            ("Include the phase relative permeabilities in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteViscosities>
+            ("Include component phase viscosities in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteAverageMolarMasses>
+            ("Include the average phase mass in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePorosity>
+            ("Include the porosity in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteIntrinsicPermeabilities>
+            ("Include the intrinsic permeability in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteFilterVelocities>
+            ("Include in the filter velocities of the phases the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePotentialGradients>
+            ("Include the phase pressure potential gradients in the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkphasepresencemodule.hh
+++ b/opm/models/io/vtkphasepresencemodule.hh
@@ -83,9 +83,9 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePhasePresence,
-                             "Include the phase presence pseudo primary "
-                             "variable in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePhasePresence>
+            ("Include the phase presence pseudo primary "
+             "variable in the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkprimaryvarsmodule.hh
+++ b/opm/models/io/vtkprimaryvarsmodule.hh
@@ -93,12 +93,12 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePrimaryVars,
-                             "Include the primary variables into the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteProcessRank,
-                             "Include the MPI process rank into the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteDofIndex,
-                             "Include the index of the degrees of freedom into the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWritePrimaryVars>
+            ("Include the primary variables into the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteProcessRank>
+            ("Include the MPI process rank into the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteDofIndex>
+            ("Include the index of the degrees of freedom into the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtkptflashmodule.hh
+++ b/opm/models/io/vtkptflashmodule.hh
@@ -99,10 +99,10 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteLiquidMoleFractions,
-                             "Include liquid mole fractions (L) in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteEquilibriumConstants,
-                             "Include equilibrium constants (K) in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteLiquidMoleFractions>
+            ("Include liquid mole fractions (L) in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteEquilibriumConstants>
+            ("Include equilibrium constants (K) in the VTK output files");
     }
 
     /*!

--- a/opm/models/io/vtktemperaturemodule.hh
+++ b/opm/models/io/vtktemperaturemodule.hh
@@ -88,8 +88,8 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteTemperature,
-                             "Include the temperature in the VTK output files");
+        Parameters::registerParam<TypeTag, Properties::VtkWriteTemperature>
+            ("Include the temperature in the VTK output files");
     }
 
     /*!

--- a/opm/models/nonlinear/newtonmethod.hh
+++ b/opm/models/nonlinear/newtonmethod.hh
@@ -151,25 +151,22 @@ public:
     {
         LinearSolverBackend::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, bool, NewtonVerbose,
-                             "Specify whether the Newton method should inform "
-                             "the user about its progress or not");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, NewtonWriteConvergence,
-                             "Write the convergence behaviour of the Newton "
-                             "method to a VTK file");
-        EWOMS_REGISTER_PARAM(TypeTag, int, NewtonTargetIterations,
-                             "The 'optimum' number of Newton iterations per "
-                             "time step");
-        EWOMS_REGISTER_PARAM(TypeTag, int, NewtonMaxIterations,
-                             "The maximum number of Newton iterations per time "
-                             "step");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, NewtonTolerance,
-                             "The maximum raw error tolerated by the Newton"
-                             "method for considering a solution to be "
-                             "converged");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, NewtonMaxError,
-                             "The maximum error tolerated by the Newton "
-                             "method to which does not cause an abort");
+        Parameters::registerParam<TypeTag, Properties::NewtonVerbose>
+            ("Specify whether the Newton method should inform "
+             "the user about its progress or not");
+        Parameters::registerParam<TypeTag, Properties::NewtonWriteConvergence>
+            ("Write the convergence behaviour of the Newton "
+             "method to a VTK file");
+        Parameters::registerParam<TypeTag, Properties::NewtonTargetIterations>
+            ("The 'optimum' number of Newton iterations per time step");
+        Parameters::registerParam<TypeTag, Properties::NewtonMaxIterations>
+            ("The maximum number of Newton iterations per time step");
+        Parameters::registerParam<TypeTag, Properties::NewtonTolerance>
+            ("The maximum raw error tolerated by the Newton"
+             "method for considering a solution to be converged");
+        Parameters::registerParam<TypeTag, Properties::NewtonMaxError>
+            ("The maximum error tolerated by the Newton "
+             "method to which does not cause an abort");
     }
 
     /*!

--- a/opm/models/parallel/threadmanager.hh
+++ b/opm/models/parallel/threadmanager.hh
@@ -31,6 +31,7 @@
 #include <omp.h>
 #endif
 
+#include <opm/models/discretization/common/fvbaseproperties.hh>
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/models/utils/propertysystem.hh>
 
@@ -59,9 +60,9 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, int, ThreadsPerProcess,
-                             "The maximum number of threads to be instantiated per process "
-                             "('-1' means 'automatic')");
+        Parameters::registerParam<TypeTag, Properties::ThreadsPerProcess>
+            ("The maximum number of threads to be instantiated per process "
+             "('-1' means 'automatic')");
     }
 
     /*!

--- a/opm/models/ptflash/flashmodel.hh
+++ b/opm/models/ptflash/flashmodel.hh
@@ -233,14 +233,14 @@ public:
         if (enableEnergy)
             Opm::VtkEnergyModule<TypeTag>::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, FlashTolerance,
-                             "The maximum tolerance for the flash solver to "
-                             "consider the solution converged");
-        EWOMS_REGISTER_PARAM(TypeTag, int, FlashVerbosity,
-                             "Flash solver verbosity level");
-        EWOMS_REGISTER_PARAM(TypeTag, std::string, FlashTwoPhaseMethod,
-                             "Method for solving vapor-liquid composition. Available options include:"
-                             "ssi, newton, ssi+newton");
+        Parameters::registerParam<TypeTag, Properties::FlashTolerance>
+            ("The maximum tolerance for the flash solver to "
+             "consider the solution converged");
+        Parameters::registerParam<TypeTag, Properties::FlashVerbosity>
+            ("Flash solver verbosity level");
+        Parameters::registerParam<TypeTag, Properties::FlashTwoPhaseMethod>
+            ("Method for solving vapor-liquid composition. Available options include: "
+             "ssi, newton, ssi+newton");
     }
 
     /*!

--- a/opm/models/pvs/pvsmodel.hh
+++ b/opm/models/pvs/pvsmodel.hh
@@ -296,9 +296,9 @@ public:
         if (enableEnergy)
             Opm::VtkEnergyModule<TypeTag>::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, int, PvsVerbosity,
-                             "The verbosity level of the primary variable "
-                             "switching model");
+        Parameters::registerParam<TypeTag, Properties::PvsVerbosity>
+            ("The verbosity level of the primary variable "
+             "switching model");
     }
 
     /*!

--- a/opm/models/utils/parametersystem.hh
+++ b/opm/models/utils/parametersystem.hh
@@ -71,8 +71,8 @@
  * \endcode
  */
 #define EWOMS_REGISTER_PARAM(TypeTag, ParamType, ParamName, Description)       \
-    ::Opm::Parameters::registerParam<TypeTag, ParamType>( \
-        #ParamName, getPropValue<TypeTag, Properties::ParamName>(), Description)
+        ::Opm::Parameters::registerParam<TypeTag, Properties::ParamName>( \
+        #ParamName, Description)
 
 /*!
  * \ingroup Parameter
@@ -1102,14 +1102,18 @@ bool isSet(const char* paramName, bool errorIfNotRegistered = true)
                                                      errorIfNotRegistered);
 }
 
-template <class TypeTag, class ParamType>
-void registerParam(const char* paramName, const ParamType& defaultValue, const char* usageString)
+template <class TypeTag, template<class,class> class Param>
+void registerParam(const char* paramName, const char* usageString)
 {
     using ParamsMeta = GetProp<TypeTag, Properties::ParameterMetaData>;
     if (!ParamsMeta::registrationOpen())
         throw std::logic_error("Parameter registration was already closed before "
                                "the parameter '"+std::string(paramName)+"' was registered.");
 
+    const auto defaultValue = getPropValue<TypeTag, Param>();
+    using ParamType = std::conditional_t<std::is_same_v<decltype(defaultValue),
+                                                        const char* const>, std::string,
+                                         std::remove_const_t<decltype(defaultValue)>>;
     ParamsMeta::registrationFinalizers().emplace_back(
         new ParamRegFinalizer_<TypeTag, ParamType>(paramName, defaultValue));
 

--- a/opm/models/utils/parametersystem.hh
+++ b/opm/models/utils/parametersystem.hh
@@ -56,26 +56,6 @@
 /*!
  * \ingroup Parameter
  *
- * \brief Register a run-time parameter.
- *
- * In OPM, parameters can only be used after they have been
- * registered.
- *
- * Example:
- *
- * \code
- * // Registers a run-time parameter "UpwindWeight" which has type
- * // "Scalar" and the description "Relative weight of the upwind node."
- * EWOMS_REGISTER_PARAM(TypeTag, Scalar, UpwindWeight,
- *                      "Relative weight of the upwind node.");
- * \endcode
- */
-#define EWOMS_REGISTER_PARAM(TypeTag, ParamType, ParamName, Description)       \
-        ::Opm::Parameters::registerParam<TypeTag, Properties::ParamName>(Description)
-
-/*!
- * \ingroup Parameter
- *
  * \brief Retrieve a runtime parameter.
  *
  * The default value is specified via the property system.
@@ -1101,6 +1081,22 @@ bool isSet(const char* paramName, bool errorIfNotRegistered = true)
                                                      errorIfNotRegistered);
 }
 
+/*!
+ * \ingroup Parameter
+ *
+ * \brief Register a run-time parameter.
+ *
+ * In OPM, parameters can only be used after they have been
+ * registered.
+ *
+ * Example:
+ *
+ * \code
+ * // Registers a run-time parameter "UpwindWeight"
+ *    and the description "Relative weight of the upwind node."
+ * registerParam<TypeTag,UpwindWeight>("Relative weight of the upwind node.");
+ * \endcode
+ */
 template <class TypeTag, template<class,class> class Param>
 void registerParam(const char* usageString)
 {

--- a/opm/models/utils/parametersystem.hh
+++ b/opm/models/utils/parametersystem.hh
@@ -71,8 +71,7 @@
  * \endcode
  */
 #define EWOMS_REGISTER_PARAM(TypeTag, ParamType, ParamName, Description)       \
-        ::Opm::Parameters::registerParam<TypeTag, Properties::ParamName>( \
-        #ParamName, Description)
+        ::Opm::Parameters::registerParam<TypeTag, Properties::ParamName>(Description)
 
 /*!
  * \ingroup Parameter
@@ -1103,12 +1102,14 @@ bool isSet(const char* paramName, bool errorIfNotRegistered = true)
 }
 
 template <class TypeTag, template<class,class> class Param>
-void registerParam(const char* paramName, const char* usageString)
+void registerParam(const char* usageString)
 {
     using ParamsMeta = GetProp<TypeTag, Properties::ParameterMetaData>;
-    if (!ParamsMeta::registrationOpen())
+    const std::string paramName = getPropName<TypeTag,Param>();
+    if (!ParamsMeta::registrationOpen()) {
         throw std::logic_error("Parameter registration was already closed before "
-                               "the parameter '"+std::string(paramName)+"' was registered.");
+                               "the parameter '" + paramName + "' was registered.");
+    }
 
     const auto defaultValue = getPropValue<TypeTag, Param>();
     using ParamType = std::conditional_t<std::is_same_v<decltype(defaultValue),
@@ -1132,7 +1133,7 @@ void registerParam(const char* paramName, const char* usageString)
         // parameter name, type and usage string are exactly the same.
         if (ParamsMeta::registry().at(paramName) == paramInfo)
             return;
-        throw std::logic_error("Parameter "+std::string(paramName)
+        throw std::logic_error("Parameter " + paramName
                                +" registered twice with non-matching characteristics.");
     }
 

--- a/opm/models/utils/simulator.hh
+++ b/opm/models/utils/simulator.hh
@@ -254,15 +254,15 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, EndTime,
-                             "The simulation time at which the simulation is finished [s]");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, InitialTimeStepSize,
-                             "The size of the initial time step [s]");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, RestartTime,
-                             "The simulation time at which a restart should be attempted [s]");
-        EWOMS_REGISTER_PARAM(TypeTag, std::string, PredeterminedTimeStepsFile,
-                             "A file with a list of predetermined time step sizes (one "
-                             "time step per line)");
+        Parameters::registerParam<TypeTag, Properties::EndTime>
+            ("The simulation time at which the simulation is finished [s]");
+        Parameters::registerParam<TypeTag, Properties::InitialTimeStepSize>
+            ("The size of the initial time step [s]");
+        Parameters::registerParam<TypeTag, Properties::RestartTime>
+            ("The simulation time at which a restart should be attempted [s]");
+        Parameters::registerParam<TypeTag, Properties::PredeterminedTimeStepsFile>
+            ("A file with a list of predetermined time step sizes (one "
+             "time step per line)");
 
         Vanguard::registerParameters();
         Model::registerParameters();

--- a/opm/models/utils/start.hh
+++ b/opm/models/utils/start.hh
@@ -78,15 +78,14 @@ static inline void registerAllParameters_(bool finalizeRegistration = true)
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
     using ThreadManager = GetPropType<TypeTag, Properties::ThreadManager>;
 
-    EWOMS_REGISTER_PARAM(TypeTag, std::string, ParameterFile,
-                         "An .ini file which contains a set of run-time "
-                         "parameters");
-    EWOMS_REGISTER_PARAM(TypeTag, int, PrintProperties,
-                         "Print the values of the compile time properties at "
-                         "the start of the simulation");
-    EWOMS_REGISTER_PARAM(TypeTag, int, PrintParameters,
-                         "Print the values of the run-time parameters at the "
-                         "start of the simulation");
+    Parameters::registerParam<TypeTag, Properties::ParameterFile>
+        ("An .ini file which contains a set of run-time parameters");
+    Parameters::registerParam<TypeTag, Properties::PrintProperties>
+        ("Print the values of the compile time properties at "
+         "the start of the simulation");
+    Parameters::registerParam<TypeTag, Properties::PrintParameters>
+        ("Print the values of the run-time parameters at the "
+         "start of the simulation");
 
     Simulator::registerParameters();
     ThreadManager::registerParameters();

--- a/opm/simulators/linalg/istlpreconditionerwrappers.hh
+++ b/opm/simulators/linalg/istlpreconditionerwrappers.hh
@@ -72,11 +72,10 @@ namespace Linear {
                                                                                 \
         static void registerParameters()                                        \
         {                                                                       \
-            EWOMS_REGISTER_PARAM(TypeTag, int, PreconditionerOrder,             \
-                                 "The order of the preconditioner");            \
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, PreconditionerRelaxation,     \
-                                 "The relaxation factor of the "                \
-                                 "preconditioner");                             \
+            Parameters::registerParam<TypeTag, Properties::PreconditionerOrder> \
+                ("The order of the preconditioner");                            \
+            Parameters::registerParam<TypeTag, Properties::PreconditionerRelaxation> \
+                ("The relaxation factor of the preconditioner");                \
         }                                                                       \
                                                                                 \
         void prepare(IstlMatrix& matrix)                                        \
@@ -164,8 +163,8 @@ public:
 
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, PreconditionerRelaxation,
-                             "The relaxation factor of the preconditioner");
+        Parameters::registerParam<TypeTag, Properties::PreconditionerRelaxation>
+            ("The relaxation factor of the preconditioner");
     }
 
     void prepare(OverlappingMatrix& matrix)

--- a/opm/simulators/linalg/istlsolverwrappers.hh
+++ b/opm/simulators/linalg/istlsolverwrappers.hh
@@ -124,8 +124,8 @@ public:
 
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, int, GMResRestart,
-                             "Number of iterations after which the GMRES linear solver is restarted");
+        Parameters::registerParam<TypeTag, Properties::GMResRestart>
+            ("Number of iterations after which the GMRES linear solver is restarted");
     }
 
     template <class LinearOperator, class ScalarProduct, class Preconditioner>

--- a/opm/simulators/linalg/parallelamgbackend.hh
+++ b/opm/simulators/linalg/parallelamgbackend.hh
@@ -150,12 +150,12 @@ public:
     {
         ParentType::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverMaxError,
-                             "The maximum residual error which the linear solver tolerates"
-                             " without giving up");
-        EWOMS_REGISTER_PARAM(TypeTag, int, AmgCoarsenTarget,
-                             "The coarsening target for the agglomerations of "
-                             "the AMG preconditioner");
+        Parameters::registerParam<TypeTag, Properties::LinearSolverMaxError>
+            ("The maximum residual error which the linear solver tolerates "
+             "without giving up");
+        Parameters::registerParam<TypeTag, Properties::AmgCoarsenTarget>
+            ("The coarsening target for the agglomerations of "
+             "the AMG preconditioner");
     }
 
 protected:

--- a/opm/simulators/linalg/parallelbasebackend.hh
+++ b/opm/simulators/linalg/parallelbasebackend.hh
@@ -152,16 +152,16 @@ public:
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverTolerance,
-                             "The maximum allowed error between of the linear solver");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverAbsTolerance,
-                             "The maximum accepted error of the norm of the residual");
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, LinearSolverOverlapSize,
-                             "The size of the algebraic overlap for the linear solver");
-        EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverMaxIterations,
-                             "The maximum number of iterations of the linear solver");
-        EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverVerbosity,
-                             "The verbosity level of the linear solver");
+        Parameters::registerParam<TypeTag, Properties::LinearSolverTolerance>
+            ("The maximum allowed error between of the linear solver");
+        Parameters::registerParam<TypeTag, Properties::LinearSolverAbsTolerance>
+            ("The maximum accepted error of the norm of the residual");
+        Parameters::registerParam<TypeTag, Properties::LinearSolverOverlapSize>
+            ("The size of the algebraic overlap for the linear solver");
+        Parameters::registerParam<TypeTag, Properties::LinearSolverMaxIterations>
+            ("The maximum number of iterations of the linear solver");
+        Parameters::registerParam<TypeTag, Properties::LinearSolverVerbosity>
+            ("The verbosity level of the linear solver");
 
         PreconditionerWrapper::registerParameters();
     }

--- a/opm/simulators/linalg/parallelbicgstabbackend.hh
+++ b/opm/simulators/linalg/parallelbicgstabbackend.hh
@@ -121,9 +121,9 @@ public:
     {
         ParentType::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverMaxError,
-                             "The maximum residual error which the linear solver tolerates"
-                             " without giving up");
+        Parameters::registerParam<TypeTag, Properties::LinearSolverMaxError>
+            ("The maximum residual error which the linear solver tolerates"
+             " without giving up");
     }
 
 protected:

--- a/tests/problems/co2injectionproblem.hh
+++ b/tests/problems/co2injectionproblem.hh
@@ -373,33 +373,24 @@ public:
     {
         ParentType::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, FluidSystemTemperatureLow,
-                             "The lower temperature [K] for tabulation of the "
-                             "fluid system");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, FluidSystemTemperatureHigh,
-                             "The upper temperature [K] for tabulation of the "
-                             "fluid system");
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, FluidSystemNumTemperature,
-                             "The number of intervals between the lower and "
-                             "upper temperature");
-
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, FluidSystemPressureLow,
-                             "The lower pressure [Pa] for tabulation of the "
-                             "fluid system");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, FluidSystemPressureHigh,
-                             "The upper pressure [Pa] for tabulation of the "
-                             "fluid system");
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, FluidSystemNumPressure,
-                             "The number of intervals between the lower and "
-                             "upper pressure");
-
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, Temperature,
-                             "The temperature [K] in the reservoir");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaxDepth,
-                             "The maximum depth [m] of the reservoir");
-        EWOMS_REGISTER_PARAM(TypeTag, std::string, SimulationName,
-                             "The name of the simulation used for the output "
-                             "files");
+        Parameters::registerParam<TypeTag, Properties::FluidSystemTemperatureLow>
+            ("The lower temperature [K] for tabulation of the fluid system");
+        Parameters::registerParam<TypeTag, Properties::FluidSystemTemperatureHigh>
+            ("The upper temperature [K] for tabulation of the fluid system");
+        Parameters::registerParam<TypeTag, Properties::FluidSystemNumTemperature>
+            ("The number of intervals between the lower and upper temperature");
+        Parameters::registerParam<TypeTag, Properties::FluidSystemPressureLow>
+            ("The lower pressure [Pa] for tabulation of the fluid system");
+        Parameters::registerParam<TypeTag, Properties::FluidSystemPressureHigh>
+            ("The upper pressure [Pa] for tabulation of the fluid system");
+        Parameters::registerParam<TypeTag, Properties::FluidSystemNumPressure>
+            ("The number of intervals between the lower and upper pressure");
+        Parameters::registerParam<TypeTag, Properties::Temperature>
+            ("The temperature [K] in the reservoir");
+        Parameters::registerParam<TypeTag, Properties::MaxDepth>
+            ("The maximum depth [m] of the reservoir");
+        Parameters::registerParam<TypeTag, Properties::SimulationName>
+            ("The name of the simulation used for the output files");
     }
 
     /*!

--- a/tests/problems/co2ptflashproblem.hh
+++ b/tests/problems/co2ptflashproblem.hh
@@ -407,17 +407,14 @@ public:
     {
         ParentType::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, Temperature, 
-                            "The temperature [K] in the reservoir");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, Initialpressure, 
-                            "The initial pressure [Pa s] in the reservoir");
-        EWOMS_REGISTER_PARAM(TypeTag,
-                             std::string,
-                             SimulationName,
-                             "The name of the simulation used for the output "
-                             "files");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, EpisodeLength, 
-                            "Time interval [s] for episode length");
+        Parameters::registerParam<TypeTag, Properties::Temperature>
+            ("The temperature [K] in the reservoir");
+        Parameters::registerParam<TypeTag, Properties::Initialpressure>
+            ("The initial pressure [Pa s] in the reservoir");
+        Parameters::registerParam<TypeTag, Properties::SimulationName>
+            ("The name of the simulation used for the output files");
+        Parameters::registerParam<TypeTag, Properties::EpisodeLength>
+            ("Time interval [s] for episode length");
     }
 
     /*!

--- a/tests/problems/fingerproblem.hh
+++ b/tests/problems/fingerproblem.hh
@@ -305,9 +305,8 @@ public:
     {
         ParentType::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, InitialWaterSaturation,
-                             "The initial saturation in the domain [] of the "
-                             "wetting phase");
+        Parameters::registerParam<TypeTag, Properties::InitialWaterSaturation>
+            ("The initial saturation in the domain [] of the wetting phase");
     }
 
     /*!

--- a/tests/problems/groundwaterproblem.hh
+++ b/tests/problems/groundwaterproblem.hh
@@ -263,36 +263,29 @@ public:
     {
         ParentType::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensLowerLeftX,
-                             "The x-coordinate of the lens' lower-left corner "
-                             "[m].");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensUpperRightX,
-                             "The x-coordinate of the lens' upper-right corner "
-                             "[m].");
+        Parameters::registerParam<TypeTag, Properties::LensLowerLeftX>
+            ("The x-coordinate of the lens' lower-left corner [m].");
+        Parameters::registerParam<TypeTag, Properties::LensUpperRightX>
+            ("The x-coordinate of the lens' upper-right corner [m].");
 
         if (dimWorld > 1) {
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensLowerLeftY,
-                                 "The y-coordinate of the lens' lower-left "
-                                 "corner [m].");
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensUpperRightY,
-                                 "The y-coordinate of the lens' upper-right "
-                                 "corner [m].");
+            Parameters::registerParam<TypeTag, Properties::LensLowerLeftY>
+                ("The y-coordinate of the lens' lower-left corner [m].");
+            Parameters::registerParam<TypeTag, Properties::LensUpperRightY>
+                ("The y-coordinate of the lens' upper-right corner [m].");
         }
 
         if (dimWorld > 2) {
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensLowerLeftZ,
-                                 "The z-coordinate of the lens' lower-left "
-                                 "corner [m].");
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensUpperRightZ,
-                                 "The z-coordinate of the lens' upper-right "
-                                 "corner [m].");
+            Parameters::registerParam<TypeTag, Properties::LensLowerLeftZ>
+                ("The z-coordinate of the lens' lower-left corner [m].");
+            Parameters::registerParam<TypeTag, Properties::LensUpperRightZ>
+                ("The z-coordinate of the lens' upper-right corner [m].");
         }
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, Permeability,
-                             "The intrinsic permeability [m^2] of the ambient "
-                             "material.");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, PermeabilityLens,
-                             "The intrinsic permeability [m^2] of the lens.");
+        Parameters::registerParam<TypeTag, Properties::Permeability>
+            ("The intrinsic permeability [m^2] of the ambient material.");
+        Parameters::registerParam<TypeTag, Properties::PermeabilityLens>
+            ("The intrinsic permeability [m^2] of the lens.");
     }
 
     /*!

--- a/tests/problems/lensproblem.hh
+++ b/tests/problems/lensproblem.hh
@@ -362,26 +362,20 @@ public:
     {
         ParentType::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensLowerLeftX,
-                             "The x-coordinate of the lens' lower-left corner "
-                             "[m].");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensLowerLeftY,
-                             "The y-coordinate of the lens' lower-left corner "
-                             "[m].");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensUpperRightX,
-                             "The x-coordinate of the lens' upper-right corner "
-                             "[m].");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensUpperRightY,
-                             "The y-coordinate of the lens' upper-right corner "
-                             "[m].");
+        Parameters::registerParam<TypeTag, Properties::LensLowerLeftX>
+            ("The x-coordinate of the lens' lower-left corner [m].");
+        Parameters::registerParam<TypeTag, Properties::LensLowerLeftY>
+            ("The y-coordinate of the lens' lower-left corner [m].");
+        Parameters::registerParam<TypeTag, Properties::LensUpperRightX>
+            ("The x-coordinate of the lens' upper-right corner [m].");
+        Parameters::registerParam<TypeTag, Properties::LensUpperRightY>
+            ("The y-coordinate of the lens' upper-right corner [m].");
 
         if (dimWorld == 3) {
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensLowerLeftZ,
-                                 "The z-coordinate of the lens' lower-left "
-                                 "corner [m].");
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, LensUpperRightZ,
-                                 "The z-coordinate of the lens' upper-right "
-                                 "corner [m].");
+            Parameters::registerParam<TypeTag, Properties::LensLowerLeftZ>
+                ("The z-coordinate of the lens' lower-left corner [m].");
+            Parameters::registerParam<TypeTag, Properties::LensUpperRightZ>
+                ("The z-coordinate of the lens' upper-right corner [m].");
         }
     }
 

--- a/tests/problems/reservoirproblem.hh
+++ b/tests/problems/reservoirproblem.hh
@@ -426,13 +426,13 @@ public:
     {
         ParentType::registerParameters();
 
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, Temperature,
-                             "The temperature [K] in the reservoir");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaxDepth,
-                             "The maximum depth [m] of the reservoir");
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, WellWidth,
-                             "The width of producer/injector wells as a fraction of the width"
-                             " of the spatial domain");
+        Parameters::registerParam<TypeTag, Properties::Temperature>
+            ("The temperature [K] in the reservoir");
+        Parameters::registerParam<TypeTag, Properties::MaxDepth>
+            ("The maximum depth [m] of the reservoir");
+        Parameters::registerParam<TypeTag, Properties::WellWidth>
+            ("The width of producer/injector wells as a fraction of the width"
+             " of the spatial domain");
     }
 
     /*!


### PR DESCRIPTION
Make things more DRY by using reading parameter type from struct definition and by deriving the parameter name from the struct name. The latter can optionally be overridden by having a name member in the struct.