### PR TITLE
fixed: inconsistent parameter setups

### DIFF
--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -123,7 +123,7 @@ struct GradientCalculator<TypeTag, TTag::FvBaseDiscretization> { using type = Fv
 //! The maximum allowed number of timestep divisions for the
 //! Newton solver
 template<class TypeTag>
-struct MaxTimeStepDivisions<TypeTag, TTag::FvBaseDiscretization> { static constexpr int value = 10; };
+struct MaxTimeStepDivisions<TypeTag, TTag::FvBaseDiscretization> { static constexpr unsigned value = 10; };
 
 
 //! By default, do not continue with a non-converged solution instead of giving up

--- a/opm/models/utils/basicproperties.hh
+++ b/opm/models/utils/basicproperties.hh
@@ -236,7 +236,7 @@ struct ParameterFile<TypeTag, TTag::NumericModel> { static constexpr auto value 
 //! Set the number of refinement levels of the grid to 0. This does not belong
 //! here, strictly speaking.
 template<class TypeTag>
-struct GridGlobalRefinements<TypeTag, TTag::NumericModel> { static constexpr int value = 0; };
+struct GridGlobalRefinements<TypeTag, TTag::NumericModel> { static constexpr unsigned value = 0; };
 
 //! By default, print the properties on startup
 template<class TypeTag>

--- a/opm/simulators/linalg/parallelbasebackend.hh
+++ b/opm/simulators/linalg/parallelbasebackend.hh
@@ -460,7 +460,7 @@ struct PreconditionerWrapper<TypeTag, TTag::ParallelBaseLinearSolver>
 
 //! set the default overlap size to 2
 template<class TypeTag>
-struct LinearSolverOverlapSize<TypeTag, TTag::ParallelBaseLinearSolver> { static constexpr int value = 2; };
+struct LinearSolverOverlapSize<TypeTag, TTag::ParallelBaseLinearSolver> { static constexpr unsigned value = 2; };
 
 //! set the default number of maximum iterations for the linear solver
 template<class TypeTag>

--- a/tests/problems/co2injectionproblem.hh
+++ b/tests/problems/co2injectionproblem.hh
@@ -179,7 +179,7 @@ struct FluidSystemPressureHigh<TypeTag, TTag::Co2InjectionBaseProblem>
     static constexpr type value = 4e7;
 };
 template<class TypeTag>
-struct FluidSystemNumPressure<TypeTag, TTag::Co2InjectionBaseProblem> { static constexpr int value = 100; };
+struct FluidSystemNumPressure<TypeTag, TTag::Co2InjectionBaseProblem> { static constexpr unsigned value = 100; };
 template<class TypeTag>
 struct FluidSystemTemperatureLow<TypeTag, TTag::Co2InjectionBaseProblem>
 {
@@ -193,7 +193,7 @@ struct FluidSystemTemperatureHigh<TypeTag, TTag::Co2InjectionBaseProblem>
     static constexpr type value = 500;
 };
 template<class TypeTag>
-struct FluidSystemNumTemperature<TypeTag, TTag::Co2InjectionBaseProblem> { static constexpr int value = 100; };
+struct FluidSystemNumTemperature<TypeTag, TTag::Co2InjectionBaseProblem> { static constexpr unsigned value = 100; };
 
 template<class TypeTag>
 struct MaxDepth<TypeTag, TTag::Co2InjectionBaseProblem>

--- a/tests/problems/co2ptflashproblem.hh
+++ b/tests/problems/co2ptflashproblem.hh
@@ -202,8 +202,7 @@ struct NewtonTolerance<TypeTag, TTag::CO2PTBaseProblem> {
 
 template <class TypeTag>
 struct NewtonMaxIterations<TypeTag, TTag::CO2PTBaseProblem> {
-    using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 30;
+    static constexpr int value = 30;
 };
 
 template <class TypeTag>
@@ -284,12 +283,12 @@ struct DomainSizeZ<TypeTag, TTag::CO2PTBaseProblem> {
 };
 
 template<class TypeTag>
-struct CellsX<TypeTag, TTag::CO2PTBaseProblem> { static constexpr int value = 30; };
+struct CellsX<TypeTag, TTag::CO2PTBaseProblem> { static constexpr unsigned value = 30; };
 template<class TypeTag>
-struct CellsY<TypeTag, TTag::CO2PTBaseProblem> { static constexpr int value = 1; };
+struct CellsY<TypeTag, TTag::CO2PTBaseProblem> { static constexpr unsigned value = 1; };
 // CellsZ is not needed, while to keep structuredgridvanguard.hh compile
 template<class TypeTag>
-struct CellsZ<TypeTag, TTag::CO2PTBaseProblem> { static constexpr int value = 1; };
+struct CellsZ<TypeTag, TTag::CO2PTBaseProblem> { static constexpr unsigned value = 1; };
 
 template <class TypeTag>
 struct EnableEnergy<TypeTag, TTag::CO2PTBaseProblem> {

--- a/tests/problems/diffusionproblem.hh
+++ b/tests/problems/diffusionproblem.hh
@@ -131,11 +131,11 @@ struct DomainSizeZ<TypeTag, TTag::DiffusionBaseProblem>
 };
 
 template<class TypeTag>
-struct CellsX<TypeTag, TTag::DiffusionBaseProblem> { static constexpr int value = 250; };
+struct CellsX<TypeTag, TTag::DiffusionBaseProblem> { static constexpr unsigned value = 250; };
 template<class TypeTag>
-struct CellsY<TypeTag, TTag::DiffusionBaseProblem> { static constexpr int value = 1; };
+struct CellsY<TypeTag, TTag::DiffusionBaseProblem> { static constexpr unsigned value = 1; };
 template<class TypeTag>
-struct CellsZ<TypeTag, TTag::DiffusionBaseProblem> { static constexpr int value = 1; };
+struct CellsZ<TypeTag, TTag::DiffusionBaseProblem> { static constexpr unsigned value = 1; };
 
 // The default for the end time of the simulation
 template<class TypeTag>

--- a/tests/problems/fingerproblem.hh
+++ b/tests/problems/fingerproblem.hh
@@ -168,11 +168,11 @@ struct InitialWaterSaturation<TypeTag, TTag::FingerBaseProblem>
 };
 
 template<class TypeTag>
-struct CellsX<TypeTag, TTag::FingerBaseProblem> { static constexpr int value = 20; };
+struct CellsX<TypeTag, TTag::FingerBaseProblem> { static constexpr unsigned value = 20; };
 template<class TypeTag>
-struct CellsY<TypeTag, TTag::FingerBaseProblem> { static constexpr int value = 70; };
+struct CellsY<TypeTag, TTag::FingerBaseProblem> { static constexpr unsigned value = 70; };
 template<class TypeTag>
-struct CellsZ<TypeTag, TTag::FingerBaseProblem> { static constexpr int value = 1; };
+struct CellsZ<TypeTag, TTag::FingerBaseProblem> { static constexpr unsigned value = 1; };
 
 // The default for the end time of the simulation
 template<class TypeTag>

--- a/tests/problems/lensproblem.hh
+++ b/tests/problems/lensproblem.hh
@@ -199,11 +199,11 @@ struct DomainSizeZ<TypeTag, TTag::LensBaseProblem>
 };
 
 template<class TypeTag>
-struct CellsX<TypeTag, TTag::LensBaseProblem> { static constexpr int value = 48; };
+struct CellsX<TypeTag, TTag::LensBaseProblem> { static constexpr unsigned value = 48; };
 template<class TypeTag>
-struct CellsY<TypeTag, TTag::LensBaseProblem> { static constexpr int value = 32; };
+struct CellsY<TypeTag, TTag::LensBaseProblem> { static constexpr unsigned value = 32; };
 template<class TypeTag>
-struct CellsZ<TypeTag, TTag::LensBaseProblem> { static constexpr int value = 16; };
+struct CellsZ<TypeTag, TTag::LensBaseProblem> { static constexpr unsigned value = 16; };
 
 // The default for the end time of the simulation
 template<class TypeTag>

--- a/tests/problems/powerinjectionproblem.hh
+++ b/tests/problems/powerinjectionproblem.hh
@@ -148,11 +148,11 @@ struct DomainSizeZ<TypeTag, TTag::PowerInjectionBaseProblem>
 };
 
 template<class TypeTag>
-struct CellsX<TypeTag, TTag::PowerInjectionBaseProblem> { static constexpr int value = 250; };
+struct CellsX<TypeTag, TTag::PowerInjectionBaseProblem> { static constexpr unsigned value = 250; };
 template<class TypeTag>
-struct CellsY<TypeTag, TTag::PowerInjectionBaseProblem> { static constexpr int value = 1; };
+struct CellsY<TypeTag, TTag::PowerInjectionBaseProblem> { static constexpr unsigned value = 1; };
 template<class TypeTag>
-struct CellsZ<TypeTag, TTag::PowerInjectionBaseProblem> { static constexpr int value = 1; };
+struct CellsZ<TypeTag, TTag::PowerInjectionBaseProblem> { static constexpr unsigned value = 1; };
 
 // The default for the end time of the simulation
 template<class TypeTag>

--- a/tutorial/tutorial1problem.hh
+++ b/tutorial/tutorial1problem.hh
@@ -162,11 +162,11 @@ struct DomainSizeZ<TypeTag, TTag::Tutorial1Problem>
 
 // // define the number of cells used for discretizing the physical domain
 template<class TypeTag>
-struct CellsX<TypeTag, TTag::Tutorial1Problem> { static constexpr int value = 100; };
+struct CellsX<TypeTag, TTag::Tutorial1Problem> { static constexpr unsigned value = 100; };
 template<class TypeTag>
-struct CellsY<TypeTag, TTag::Tutorial1Problem> { static constexpr int value = 1; };
+struct CellsY<TypeTag, TTag::Tutorial1Problem> { static constexpr unsigned value = 1; };
 template<class TypeTag>
-struct CellsZ<TypeTag, TTag::Tutorial1Problem> { static constexpr int value = 1; }; /*@\label{tutorial1:default-params-end}@*/
+struct CellsZ<TypeTag, TTag::Tutorial1Problem> { static constexpr unsigned value = 1; }; /*@\label{tutorial1:default-params-end}@*/
 
 } // namespace Opm::Properties
 


### PR DESCRIPTION
registered as int and obtained as unsigned, or registered as Scalar and obtained as int