### PR TITLE
extending drsdtcon with regimes, and option for GAS/WATER

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -63,6 +63,7 @@ list (APPEND PROGRAM_SOURCE_FILES
 list (APPEND PUBLIC_HEADER_FILES
              opm/models/blackoil/blackoilmodel.hh
              opm/models/blackoil/blackoildiffusionmodule.hh
+             opm/models/blackoil/blackoilconvectivemixingmodule.hh
              opm/models/blackoil/blackoildispersionmodule.hh
              opm/models/blackoil/blackoilextensivequantities.hh
              opm/models/blackoil/blackoilintensivequantities.hh

--- a/opm/models/blackoil/blackoilconvectivemixingmodule.hh
+++ b/opm/models/blackoil/blackoilconvectivemixingmodule.hh
@@ -1,0 +1,269 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Classes required for molecular diffusion.
+ */
+#ifndef EWOMS_CONVECTIVEMIXING_MODULE_HH
+#define EWOMS_CONVECTIVEMIXING_MODULE_HH
+
+#include <opm/models/discretization/common/fvbaseproperties.hh>
+#include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/material/common/Valgrind.hpp>
+
+#include <dune/common/fvector.hh>
+
+#include <stdexcept>
+#include <iostream>
+
+namespace Opm {
+
+/*!
+ * \copydoc Opm::BlackOilConvectiveMixingModule
+ * \brief Provides the requiered methods for dynamic convective mixing.
+ */
+template <class TypeTag>
+class BlackOilConvectiveMixingModule
+{
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+    using RateVector = GetPropType<TypeTag, Properties::RateVector>;
+    using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
+    using Indices = GetPropType<TypeTag, Properties::Indices>;
+    using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
+    using GridView = GetPropType<TypeTag, Properties::GridView>;
+
+    enum { conti0EqIdx = Indices::conti0EqIdx };
+    enum { dimWorld = GridView::dimensionworld };
+
+public:
+
+    struct ConvectiveMixingModuleParam
+    {
+        bool active_;
+        std::vector<Scalar> Xhi_;
+        std::vector<Scalar> Psi_;
+    };
+
+    #if HAVE_ECL_INPUT
+    static void beginEpisode(const EclipseState& eclState, const Schedule& schedule, const int episodeIdx, ConvectiveMixingModuleParam& info)
+    {
+        // check that Xhi and Psi didn't change
+        std::size_t numRegions = eclState.runspec().tabdims().getNumPVTTables();
+        const auto& control = schedule[episodeIdx].oilvap();
+        if (!info.active_) {
+            return;
+        }
+        if (info.Xhi_.empty()) {
+            info.Xhi_.resize(numRegions); 
+            info.Psi_.resize(numRegions); 
+        }
+        for (size_t i = 0; i < numRegions; ++i ) {
+            info.Xhi_[i] = control.getMaxDRSDT(i);
+            info.Psi_[i] = control.getPsi(i);
+        }
+    }
+    #endif
+
+    template <class Context>
+    static void addConvectiveMixingFlux(RateVector& flux, 
+                                        const Context& elemCtx,
+                                        unsigned scvfIdx, 
+                                        unsigned timeIdx)
+    {
+
+        // need for dary flux calculation
+        const auto& problem = elemCtx.problem();
+        const auto& stencil = elemCtx.stencil(timeIdx);
+        const auto& scvf = stencil.interiorFace(scvfIdx);
+
+        unsigned interiorDofIdx = scvf.interiorIndex();
+        unsigned exteriorDofIdx = scvf.exteriorIndex();
+        assert(interiorDofIdx != exteriorDofIdx);
+
+        const auto& globalIndexIn = stencil.globalSpaceIndex(interiorDofIdx);
+        const auto& globalIndexEx = stencil.globalSpaceIndex(exteriorDofIdx);
+        Scalar trans = problem.transmissibility(elemCtx, interiorDofIdx, exteriorDofIdx);
+        Scalar faceArea = scvf.area();
+        const Scalar g = problem.gravity()[dimWorld - 1];
+        const auto& intQuantsIn = elemCtx.intensiveQuantities(interiorDofIdx, timeIdx);
+        const auto& intQuantsEx = elemCtx.intensiveQuantities(exteriorDofIdx, timeIdx);
+        const Scalar zIn = problem.dofCenterDepth(elemCtx, interiorDofIdx, timeIdx);
+        const Scalar zEx = problem.dofCenterDepth(elemCtx, exteriorDofIdx, timeIdx);
+        const Scalar distZ = zIn - zEx;
+        addConvectiveMixingFlux(flux,
+                                intQuantsIn,
+                                intQuantsEx,
+                                globalIndexIn,
+                                globalIndexEx,
+                                distZ * g,
+                                trans,
+                                faceArea,
+                                problem.moduleParams().convectiveMixingModuleParam);
+    }
+
+
+
+
+
+    /*!
+     * \brief Adds the diffusive mass flux flux to the flux vector over a flux
+     *        integration point.
+      */
+    static void addConvectiveMixingFlux(RateVector& flux,
+                            const IntensiveQuantities& intQuantsIn,
+                            const IntensiveQuantities& intQuantsEx,
+                            const unsigned globalIndexIn,
+                            const unsigned globalIndexEx,
+                            const Scalar distZg, 
+                            const Scalar trans,
+                            const Scalar faceArea,
+                            const ConvectiveMixingModuleParam& info)
+    {
+
+
+        if (!info.active_) {
+            return;
+        }
+
+        const auto& liquidPhaseIdx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+            FluidSystem::waterPhaseIdx : 
+            FluidSystem::oilPhaseIdx;
+        const Evaluation SoMax = 0.0;
+
+        //interiour
+        const Scalar rs_zero_in = 0.0;
+        const auto& t_in = Opm::getValue(intQuantsIn.fluidState().temperature(liquidPhaseIdx));
+        const auto& p_in = Opm::getValue(intQuantsIn.fluidState().pressure(liquidPhaseIdx));
+        const auto& rssat_in = FluidSystem::saturatedDissolutionFactor(intQuantsIn.fluidState(),
+                                                            liquidPhaseIdx,
+                                                            intQuantsIn.pvtRegionIndex(),
+                                                            SoMax);
+
+        const auto& salt_in = Opm::getValue(intQuantsIn.fluidState().saltSaturation());
+
+        const auto& bLiquidIn = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ? 
+            FluidSystem::waterPvt().inverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_in, p_in, rs_zero_in, salt_in):
+            FluidSystem::oilPvt().inverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_in, p_in, rs_zero_in);
+
+        const auto& bLiquidSatIn = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ? 
+            FluidSystem::waterPvt().saturatedInverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_in, p_in, salt_in) :
+            FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_in, p_in);
+
+        const auto& densityLiquidIn = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+            FluidSystem::waterPvt().waterReferenceDensity(intQuantsIn.pvtRegionIndex()) :
+            FluidSystem::oilPvt().oilReferenceDensity(intQuantsIn.pvtRegionIndex());
+
+        const auto rho_in = bLiquidIn * densityLiquidIn;
+        const auto rho_sat_in = bLiquidSatIn
+            * (densityLiquidIn + rssat_in * FluidSystem::referenceDensity(FluidSystem::gasPhaseIdx, intQuantsIn.pvtRegionIndex()));
+        
+        //exteriour
+        const Scalar rs_zero_ex = 0.0;
+        const auto& t_ex = Opm::getValue(intQuantsEx.fluidState().temperature(liquidPhaseIdx));
+        const auto& p_ex = Opm::getValue(intQuantsEx.fluidState().pressure(liquidPhaseIdx));
+        const auto& rssat_ex = FluidSystem::saturatedDissolutionFactor(intQuantsEx.fluidState(),
+                                                            liquidPhaseIdx,
+                                                            intQuantsEx.pvtRegionIndex(),
+                                                            SoMax);
+        const auto& salt_ex = Opm::getValue(intQuantsEx.fluidState().saltSaturation());
+            
+        const auto& bLiquidEx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ? 
+            FluidSystem::waterPvt().inverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_ex, p_ex, rs_zero_ex, salt_ex) :
+            FluidSystem::oilPvt().inverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_ex, p_ex, rs_zero_ex);
+
+        const auto& bLiquidSatEx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ? 
+            FluidSystem::waterPvt().saturatedInverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_ex, p_ex, salt_ex) :
+            FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_ex, p_ex);
+
+        const auto& densityLiquidEx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ? 
+            FluidSystem::waterPvt().waterReferenceDensity(intQuantsEx.pvtRegionIndex()) :
+            FluidSystem::oilPvt().oilReferenceDensity(intQuantsEx.pvtRegionIndex());
+
+
+        const auto rho_ex = bLiquidEx * densityLiquidEx;
+        const auto rho_sat_ex = bLiquidSatEx
+            * (densityLiquidEx + rssat_ex * FluidSystem::referenceDensity(FluidSystem::gasPhaseIdx, intQuantsEx.pvtRegionIndex()));
+        
+        //rho difference approximation
+        const auto delta_rho = (rho_sat_ex + rho_sat_in - rho_in -rho_ex)/2;
+        const auto pressure_difference_convective_mixing =  delta_rho * distZg;
+
+        //if change in pressure
+        if (Opm::abs(pressure_difference_convective_mixing) > 1e-12){
+
+            // find new upstream direction
+            short interiorDofIdx = 0;
+            short exteriorDofIdx = 1;
+            short upIdx = 0;
+            short downIdx = 1;
+
+            if (pressure_difference_convective_mixing > 0) {
+                upIdx = exteriorDofIdx;
+                downIdx = interiorDofIdx;
+            }
+
+            const auto& up = (upIdx == interiorDofIdx) ? intQuantsIn : intQuantsEx;
+            unsigned globalUpIndex = (upIdx == interiorDofIdx) ? globalIndexIn : globalIndexEx;
+
+            const auto& down = (downIdx == interiorDofIdx) ? intQuantsIn : intQuantsEx;
+            unsigned globalDownIndex = (downIdx == interiorDofIdx) ? globalIndexIn : globalIndexEx;
+
+            const auto& Rsup =  (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+                                up.fluidState().Rsw() :
+                                up.fluidState().Rs();
+            const auto& Rsdown =  (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+                                down.fluidState().Rsw() :
+                                down.fluidState().Rs();
+            
+            const auto& RsSat = FluidSystem::saturatedDissolutionFactor(up.fluidState(),
+                                                            liquidPhaseIdx,
+                                                            up.pvtRegionIndex(),
+                                                            SoMax);
+            const Evaluation& transMult = up.rockCompTransMultiplier();
+            
+            Evaluation sg = up.fluidState().saturation(FluidSystem::gasPhaseIdx);
+            Evaluation X = (Rsup - RsSat * sg) / (RsSat * ( 1.0 - sg));
+            if ( (X > info.Psi_[up.pvtRegionIndex()] || Rsdown > 0) ) {
+                const auto& invB = up.fluidState().invB(liquidPhaseIdx);
+                const auto& visc = up.fluidState().viscosity(liquidPhaseIdx);
+                // what will be the flux when muliplied with trans_mob
+                const auto convectiveFlux = -trans*transMult*info.Xhi_[up.pvtRegionIndex()]*invB*pressure_difference_convective_mixing*Rsup/(visc*faceArea);
+                unsigned activeGasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);                   
+                if (globalUpIndex == globalIndexIn)
+                    flux[conti0EqIdx + activeGasCompIdx] += convectiveFlux;
+                else
+                    flux[conti0EqIdx + activeGasCompIdx] += Opm::getValue(convectiveFlux);
+            }
+        } 
+    };
+
+};
+
+}
+#endif
+
+
+

--- a/opm/models/blackoil/blackoilconvectivemixingmodule.hh
+++ b/opm/models/blackoil/blackoilconvectivemixingmodule.hh
@@ -43,13 +43,13 @@ namespace Opm {
 /*!
  * \copydoc Opm::BlackOilConvectiveMixingModule
  * \brief Provides the convective term in the transport flux for the brine
- * when convective mixing (enhanced dissolution of CO2 in brine) occurs. 
+ * when convective mixing (enhanced dissolution of CO2 in brine) occurs.
  * Controlled by the regimes for a controlvolume:
  * i) initial phase (CO2 dissolves in brine due to diffusion)
  * ii) linear phase (Convective fingers of CO2-rich brine propagate downwards)
  * iii) steady-state-phase (fingers have passed through the bottom of a control
  * -volume but the larger scale convective process is still active)
- * iv) decline phase (Convection ceases at the large-scale when the CO2 
+ * iv) decline phase (Convection ceases at the large-scale when the CO2
  * has been completely dissolved)
  */
 
@@ -84,25 +84,32 @@ public:
     #endif
 
     template <class Context>
-    static void addConvectiveMixingFlux(RateVector& flux, 
-                                        const Context& elemCtx,
-                                        unsigned scvfIdx, 
-                                        unsigned timeIdx)
+    static bool active(const Context&) {
+        return false;
+    }
+
+    template <class Context>
+    static void addConvectiveMixingFlux(RateVector&,
+                                        const Context&,
+                                        unsigned,
+                                        unsigned)
     {}
+
     /*!
      * \brief Adds the convective mixing mass flux flux to the flux vector over a flux
      *        integration point.
      */
-    static void addConvectiveMixingFlux(RateVector& flux,
-                            const IntensiveQuantities& intQuantsIn,
-                            const IntensiveQuantities& intQuantsEx,
-                            const unsigned globalIndexIn,
-                            const unsigned globalIndexEx,
-                            const Scalar distZg, 
-                            const Scalar trans,
-                            const Scalar faceArea,
-                            const ConvectiveMixingModuleParam& info)
+    static void addConvectiveMixingFlux(RateVector&,
+                            const IntensiveQuantities&,
+                            const IntensiveQuantities&,
+                            const unsigned,
+                            const unsigned,
+                            const Scalar,
+                            const Scalar,
+                            const Scalar,
+                            const ConvectiveMixingModuleParam&)
     {}
+
 };
 template <class TypeTag>
 class BlackOilConvectiveMixingModule<TypeTag, /*enableConvectiveMixing=*/true>
@@ -122,7 +129,7 @@ public:
 
     struct ConvectiveMixingModuleParam
     {
-        bool active_;
+        bool active_{false};
         std::vector<Scalar> Xhi_;
         std::vector<Scalar> Psi_;
     };
@@ -138,8 +145,8 @@ public:
             return;
         }
         if (info.Xhi_.empty()) {
-            info.Xhi_.resize(numRegions); 
-            info.Psi_.resize(numRegions); 
+            info.Xhi_.resize(numRegions);
+            info.Psi_.resize(numRegions);
         }
         for (size_t i = 0; i < numRegions; ++i ) {
             info.Xhi_[i] = control.getMaxDRSDT(i);
@@ -149,12 +156,17 @@ public:
     #endif
 
     template <class Context>
-    static void addConvectiveMixingFlux(RateVector& flux, 
+    static bool active(const Context& elemCtx) {
+        const auto& problem = elemCtx.problem();
+        return problem.moduleParams().convectiveMixingModuleParam.active_;
+    }
+
+    template <class Context>
+    static void addConvectiveMixingFlux(RateVector& flux,
                                         const Context& elemCtx,
-                                        unsigned scvfIdx, 
+                                        unsigned scvfIdx,
                                         unsigned timeIdx)
     {
-
         // need for dary flux calculation
         const auto& problem = elemCtx.problem();
         const auto& stencil = elemCtx.stencil(timeIdx);
@@ -185,10 +197,6 @@ public:
                                 problem.moduleParams().convectiveMixingModuleParam);
     }
 
-
-
-
-
     /*!
      * \brief Adds the convective mixing mass flux flux to the flux vector over a flux
      *        integration point.
@@ -198,19 +206,17 @@ public:
                             const IntensiveQuantities& intQuantsEx,
                             const unsigned globalIndexIn,
                             const unsigned globalIndexEx,
-                            const Scalar distZg, 
+                            const Scalar distZg,
                             const Scalar trans,
                             const Scalar faceArea,
                             const ConvectiveMixingModuleParam& info)
     {
-
-
         if (!info.active_) {
             return;
         }
 
         const auto& liquidPhaseIdx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
-            FluidSystem::waterPhaseIdx : 
+            FluidSystem::waterPhaseIdx :
             FluidSystem::oilPhaseIdx;
         const Evaluation SoMax = 0.0;
 
@@ -225,11 +231,11 @@ public:
 
         const auto& salt_in = Opm::getValue(intQuantsIn.fluidState().saltSaturation());
 
-        const auto& bLiquidIn = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ? 
+        const auto& bLiquidIn = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
             FluidSystem::waterPvt().inverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_in, p_in, rs_zero_in, salt_in):
             FluidSystem::oilPvt().inverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_in, p_in, rs_zero_in);
 
-        const auto& bLiquidSatIn = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ? 
+        const auto& bLiquidSatIn = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
             FluidSystem::waterPvt().saturatedInverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_in, p_in, salt_in) :
             FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_in, p_in);
 
@@ -240,7 +246,7 @@ public:
         const auto rho_in = bLiquidIn * densityLiquidIn;
         const auto rho_sat_in = bLiquidSatIn
             * (densityLiquidIn + rssat_in * FluidSystem::referenceDensity(FluidSystem::gasPhaseIdx, intQuantsIn.pvtRegionIndex()));
-        
+
         //exteriour
         const Scalar rs_zero_ex = 0.0;
         const auto& t_ex = Opm::getValue(intQuantsEx.fluidState().temperature(liquidPhaseIdx));
@@ -250,24 +256,21 @@ public:
                                                             intQuantsEx.pvtRegionIndex(),
                                                             SoMax);
         const auto& salt_ex = Opm::getValue(intQuantsEx.fluidState().saltSaturation());
-            
-        const auto& bLiquidEx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ? 
+        const auto& bLiquidEx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
             FluidSystem::waterPvt().inverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_ex, p_ex, rs_zero_ex, salt_ex) :
             FluidSystem::oilPvt().inverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_ex, p_ex, rs_zero_ex);
 
-        const auto& bLiquidSatEx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ? 
+        const auto& bLiquidSatEx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
             FluidSystem::waterPvt().saturatedInverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_ex, p_ex, salt_ex) :
             FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(), t_ex, p_ex);
 
-        const auto& densityLiquidEx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ? 
+        const auto& densityLiquidEx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
             FluidSystem::waterPvt().waterReferenceDensity(intQuantsEx.pvtRegionIndex()) :
             FluidSystem::oilPvt().oilReferenceDensity(intQuantsEx.pvtRegionIndex());
-
 
         const auto rho_ex = bLiquidEx * densityLiquidEx;
         const auto rho_sat_ex = bLiquidSatEx
             * (densityLiquidEx + rssat_ex * FluidSystem::referenceDensity(FluidSystem::gasPhaseIdx, intQuantsEx.pvtRegionIndex()));
-        
         //rho difference approximation
         const auto delta_rho = (rho_sat_ex + rho_sat_in - rho_in -rho_ex)/2;
         const auto pressure_difference_convective_mixing =  delta_rho * distZg;
@@ -290,7 +293,6 @@ public:
             unsigned globalUpIndex = (upIdx == interiorDofIdx) ? globalIndexIn : globalIndexEx;
 
             const auto& down = (downIdx == interiorDofIdx) ? intQuantsIn : intQuantsEx;
-            unsigned globalDownIndex = (downIdx == interiorDofIdx) ? globalIndexIn : globalIndexEx;
 
             const auto& Rsup =  (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
                                 up.fluidState().Rsw() :
@@ -298,13 +300,11 @@ public:
             const auto& Rsdown =  (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
                                 down.fluidState().Rsw() :
                                 down.fluidState().Rs();
-            
             const auto& RsSat = FluidSystem::saturatedDissolutionFactor(up.fluidState(),
                                                             liquidPhaseIdx,
                                                             up.pvtRegionIndex(),
                                                             SoMax);
             const Evaluation& transMult = up.rockCompTransMultiplier();
-            
             Evaluation sg = up.fluidState().saturation(FluidSystem::gasPhaseIdx);
             Evaluation X = (Rsup - RsSat * sg) / (RsSat * ( 1.0 - sg));
             if ( (X > info.Psi_[up.pvtRegionIndex()] || Rsdown > 0) ) {
@@ -312,13 +312,13 @@ public:
                 const auto& visc = up.fluidState().viscosity(liquidPhaseIdx);
                 // what will be the flux when muliplied with trans_mob
                 const auto convectiveFlux = -trans*transMult*info.Xhi_[up.pvtRegionIndex()]*invB*pressure_difference_convective_mixing*Rsup/(visc*faceArea);
-                unsigned activeGasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);                   
+                unsigned activeGasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
                 if (globalUpIndex == globalIndexIn)
                     flux[conti0EqIdx + activeGasCompIdx] += convectiveFlux;
                 else
                     flux[conti0EqIdx + activeGasCompIdx] += Opm::getValue(convectiveFlux);
             }
-        } 
+        }
     };
 
 };

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -106,6 +106,7 @@ class BlackOilIntensiveQuantities
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
     enum { enableDispersion = getPropValue<TypeTag, Properties::EnableDispersion>() };
+    enum { enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>() };
     enum { enableMICP = getPropValue<TypeTag, Properties::EnableMICP>() };
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
     enum { numComponents = getPropValue<TypeTag, Properties::NumComponents>() };
@@ -405,8 +406,7 @@ public:
             rho = fluidState_.invB(waterPhaseIdx);
             rho *= FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
             if (FluidSystem::enableDissolvedGasInWater()) {
-                const auto& oilVaporizationControl = problem.simulator().vanguard().schedule()[problem.episodeIndex()].oilvap();
-				if(!oilVaporizationControl.drsdtConvective()) {
+				if(!enableConvectiveMixing) {
                     rho +=
                         fluidState_.invB(waterPhaseIdx) *
                         fluidState_.Rsw() *
@@ -438,8 +438,7 @@ public:
             rho = fluidState_.invB(oilPhaseIdx);
             rho *= FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
             if (FluidSystem::enableDissolvedGas()) {                
-                const auto& oilVaporizationControl = problem.simulator().vanguard().schedule()[problem.episodeIndex()].oilvap();
-				if(!oilVaporizationControl.drsdtConvective()) {
+				if(!enableConvectiveMixing) {
                     rho +=
                         fluidState_.invB(oilPhaseIdx) *
                         fluidState_.Rs() *

--- a/opm/models/blackoil/blackoillocalresidual.hh
+++ b/opm/models/blackoil/blackoillocalresidual.hh
@@ -37,6 +37,7 @@
 #include "blackoilbrinemodules.hh"
 #include "blackoildiffusionmodule.hh"
 #include "blackoilmicpmodules.hh"
+#include "blackoilconvectivemixingmodule.hh"
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
 namespace Opm {
@@ -90,6 +91,8 @@ class BlackOilLocalResidual : public GetPropType<TypeTag, Properties::DiscLocalR
     using BrineModule = BlackOilBrineModule<TypeTag>;
     using DiffusionModule = BlackOilDiffusionModule<TypeTag, enableDiffusion>;
     using MICPModule = BlackOilMICPModule<TypeTag>;
+    using ConvectiveMixingModule = BlackOilConvectiveMixingModule<TypeTag>;
+
 
 public:
     /*!
@@ -210,7 +213,7 @@ public:
             else
                 evalPhaseFluxes_<Scalar>(flux, phaseIdx, pvtRegionIdx, extQuants, up.fluidState());
         }
-
+		
         // deal with solvents (if present)
         SolventModule::computeFlux(flux, elemCtx, scvfIdx, timeIdx);
 
@@ -233,6 +236,9 @@ public:
         MICPModule::computeFlux(flux, elemCtx, scvfIdx, timeIdx);
 
         DiffusionModule::addDiffusiveFlux(flux, elemCtx, scvfIdx, timeIdx);
+
+        // deal with convective mixing (if present)
+        ConvectiveMixingModule::addConvectiveMixingFlux(flux,elemCtx, scvfIdx, timeIdx);
     }
 
     /*!

--- a/opm/models/blackoil/blackoillocalresidual.hh
+++ b/opm/models/blackoil/blackoillocalresidual.hh
@@ -94,7 +94,6 @@ class BlackOilLocalResidual : public GetPropType<TypeTag, Properties::DiscLocalR
     using MICPModule = BlackOilMICPModule<TypeTag>;
     using ConvectiveMixingModule = BlackOilConvectiveMixingModule<TypeTag, enableConvectiveMixing>;
 
-
 public:
     /*!
      * \copydoc FvBaseLocalResidual::computeStorage
@@ -214,7 +213,6 @@ public:
             else
                 evalPhaseFluxes_<Scalar>(flux, phaseIdx, pvtRegionIdx, extQuants, up.fluidState());
         }
-		
         // deal with solvents (if present)
         SolventModule::computeFlux(flux, elemCtx, scvfIdx, timeIdx);
 
@@ -238,7 +236,7 @@ public:
 
         DiffusionModule::addDiffusiveFlux(flux, elemCtx, scvfIdx, timeIdx);
 
-        // deal with convective mixing (if present)
+        // deal with convective mixing (if enabled)
         ConvectiveMixingModule::addConvectiveMixingFlux(flux,elemCtx, scvfIdx, timeIdx);
     }
 

--- a/opm/models/blackoil/blackoillocalresidual.hh
+++ b/opm/models/blackoil/blackoillocalresidual.hh
@@ -81,6 +81,7 @@ class BlackOilLocalResidual : public GetPropType<TypeTag, Properties::DiscLocalR
     static constexpr bool blackoilConserveSurfaceVolume = getPropValue<TypeTag, Properties::BlackoilConserveSurfaceVolume>();
     static constexpr bool enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>();
     static constexpr bool enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>();
+    static constexpr bool enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>();
 
     using Toolbox = MathToolbox<Evaluation>;
     using SolventModule = BlackOilSolventModule<TypeTag>;
@@ -91,7 +92,7 @@ class BlackOilLocalResidual : public GetPropType<TypeTag, Properties::DiscLocalR
     using BrineModule = BlackOilBrineModule<TypeTag>;
     using DiffusionModule = BlackOilDiffusionModule<TypeTag, enableDiffusion>;
     using MICPModule = BlackOilMICPModule<TypeTag>;
-    using ConvectiveMixingModule = BlackOilConvectiveMixingModule<TypeTag>;
+    using ConvectiveMixingModule = BlackOilConvectiveMixingModule<TypeTag, enableConvectiveMixing>;
 
 
 public:

--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -409,7 +409,7 @@ public:
                 }
             }
 
-        }      
+        }
 
         // deal with solvents (if present)
         static_assert(!enableSolvent, "Relevant computeFlux() method must be implemented for this module before enabling.");
@@ -469,7 +469,6 @@ public:
                                                             nbInfo.faceArea,
                                                             moduleParams.convectiveMixingModuleParam);
         }
-
 
         // deal with diffusion (if present). opm-models expects per area flux (added in the tmpdiffusivity).
         if constexpr(enableDiffusion){
@@ -645,7 +644,7 @@ public:
                                        RateVector& bdyFlux,
                                        const BoundaryConditionData& bdyInfo,
                                        const IntensiveQuantities& insideIntQuants,
-                                       unsigned globalSpaceIdx)
+                                       [[maybe_unused]] unsigned globalSpaceIdx)
     {
         OPM_TIMEBLOCK_LOCAL(computeBoundaryThermal);
         // only heat is allowed to flow through this boundary

--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -95,6 +95,7 @@ class BlackOilLocalResidualTPFA : public GetPropType<TypeTag, Properties::DiscLo
     static constexpr bool enableBrine = getPropValue<TypeTag, Properties::EnableBrine>();
     static constexpr bool enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>();
     static constexpr bool enableDispersion = getPropValue<TypeTag, Properties::EnableDispersion>();
+    static constexpr bool enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>();
     static constexpr bool enableMICP = getPropValue<TypeTag, Properties::EnableMICP>();
 
     using SolventModule = BlackOilSolventModule<TypeTag>;
@@ -104,7 +105,7 @@ class BlackOilLocalResidualTPFA : public GetPropType<TypeTag, Properties::DiscLo
     using FoamModule = BlackOilFoamModule<TypeTag>;
     using BrineModule = BlackOilBrineModule<TypeTag>;
     using DiffusionModule = BlackOilDiffusionModule<TypeTag, enableDiffusion>;
-    using ConvectiveMixingModule = BlackOilConvectiveMixingModule<TypeTag>;
+    using ConvectiveMixingModule = BlackOilConvectiveMixingModule<TypeTag, enableConvectiveMixing>;
     using ConvectiveMixingModuleParam = typename ConvectiveMixingModule::ConvectiveMixingModuleParam;
 
     using DispersionModule = BlackOilDispersionModule<TypeTag, enableDispersion>;
@@ -457,15 +458,17 @@ public:
         // BrineModule::computeFlux(flux, elemCtx, scvfIdx, timeIdx);
 
         // deal with convective mixing
-        ConvectiveMixingModule::addConvectiveMixingFlux(flux,
-                                                        intQuantsIn,
-                                                        intQuantsEx,
-                                                        globalIndexIn,
-                                                        globalIndexEx,
-                                                        nbInfo.dZg,
-                                                        nbInfo.trans,
-                                                        nbInfo.faceArea,
-                                                        moduleParams.convectiveMixingModuleParam);
+        if constexpr(enableConvectiveMixing){
+            ConvectiveMixingModule::addConvectiveMixingFlux(flux,
+                                                            intQuantsIn,
+                                                            intQuantsEx,
+                                                            globalIndexIn,
+                                                            globalIndexEx,
+                                                            nbInfo.dZg,
+                                                            nbInfo.trans,
+                                                            nbInfo.faceArea,
+                                                            moduleParams.convectiveMixingModuleParam);
+        }
 
 
         // deal with diffusion (if present). opm-models expects per area flux (added in the tmpdiffusivity).

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -181,6 +181,8 @@ struct EnableDiffusion<TypeTag, TTag::BlackOilModel> { static constexpr bool val
 //! disable disperison by default
 template<class TypeTag>
 struct EnableDispersion<TypeTag, TTag::BlackOilModel> { static constexpr bool value = false; };
+template<class TypeTag>
+struct EnableConvectiveMixing<TypeTag, TTag::BlackOilModel> { static constexpr bool value = false; };
 
 //! by default, scale the energy equation by the inverse of the energy required to heat
 //! up one kg of water by 30 Kelvin. If we conserve surface volumes, this must be divided

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -712,7 +712,8 @@ public:
                                                                                    pw,
                                                                                    saltConcentration);
                     setPrimaryVarsMeaningWater(WaterMeaning::Rsw);
-                    (*this)[Indices::waterSwitchIdx] = rswSat; //primary variable becomes Rsw
+                    Scalar rswMax = problem.maxGasDissolutionFactor(/*timeIdx=*/0, globalDofIdx);
+                    (*this)[Indices::waterSwitchIdx] = min(rswSat, rswMax); //primary variable becomes Rsw
                     setPrimaryVarsMeaningPressure(PressureMeaning::Pw);
                     this->setScaledPressure_(pw);
                     changed = true;
@@ -756,7 +757,8 @@ public:
                                                                                    saltConcentration);
 
                 Scalar rsw = (*this)[Indices::waterSwitchIdx];
-                if (rsw > rswSat) {
+                Scalar rswMax = problem.maxGasDissolutionFactor(/*timeIdx=*/0, globalDofIdx);
+                if (rsw > min(rswSat, rswMax)) {
                     // the gas phase appears, i.e., switch the primary variables to WaterMeaning::Sw
                     setPrimaryVarsMeaningWater(WaterMeaning::Sw);
                     (*this)[Indices::waterSwitchIdx] = 1.0; // hydrocarbon water saturation

--- a/opm/models/common/multiphasebaseproperties.hh
+++ b/opm/models/common/multiphasebaseproperties.hh
@@ -83,6 +83,9 @@ struct EnableDiffusion { using type = UndefinedProperty; };
 //! Enable dispersive fluxes?
 template<class TypeTag, class MyTypeTag>
 struct EnableDispersion { using type = UndefinedProperty; };
+//! Enable convective mixing?
+template<class TypeTag, class MyTypeTag>
+struct EnableConvectiveMixing { using type = UndefinedProperty; };
 
 } // namespace Opm::Properties
 

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -652,7 +652,7 @@ public:
             return;
         }
         const unsigned int numCells = model_().numTotalDof();
-
+        
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
@@ -673,7 +673,7 @@ public:
                 adres = 0.0;
                 darcyFlux = 0.0;
                 const IntensiveQuantities& intQuantsEx = model_().intensiveQuantities(globJ, /*timeIdx*/ 0);
-                LocalResidual::computeFlux(adres,darcyFlux, globI, globJ, intQuantsIn, intQuantsEx, nbInfo.res_nbinfo);
+                LocalResidual::computeFlux(adres,darcyFlux, globI, globJ, intQuantsIn, intQuantsEx, nbInfo.res_nbinfo, problem_().moduleParams());
                 adres *= nbInfo.res_nbinfo.faceArea;
                 if (enableFlows) {
                     for (unsigned eqIdx = 0; eqIdx < numEq; ++ eqIdx) {
@@ -759,7 +759,7 @@ private:
                 adres = 0.0;
                 darcyFlux = 0.0;
                 const IntensiveQuantities& intQuantsEx = model_().intensiveQuantities(globJ, /*timeIdx*/ 0);
-                LocalResidual::computeFlux(adres,darcyFlux, globI, globJ, intQuantsIn, intQuantsEx, nbInfo.res_nbinfo);
+                LocalResidual::computeFlux(adres,darcyFlux, globI, globJ, intQuantsIn, intQuantsEx, nbInfo.res_nbinfo,  problem_().moduleParams());
                 adres *= nbInfo.res_nbinfo.faceArea;
                 if (enableDispersion) {
                     for (unsigned phaseIdx = 0; phaseIdx < numEq; ++ phaseIdx) {

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -652,7 +652,6 @@ public:
             return;
         }
         const unsigned int numCells = model_().numTotalDof();
-        
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif


### PR DESCRIPTION
Extended the DRSDTCON to include more parameters that controls the regime and rate of convective mixing. 
Included a convective term  in the transport flux for the brine.
Also works for GAS/WATER (not only GAS/OIL as before)

Has corresponding PR in opm-common (OPM/opm-common#4097) and opm-simulators (OPM/opm-simulators#5418)