### PR TITLE
Fix runtime parameters used as properties

### DIFF
--- a/opm/models/blackoil/blackoilfoammodules.hh
+++ b/opm/models/blackoil/blackoilfoammodules.hh
@@ -78,7 +78,6 @@ class BlackOilFoamModule
     static constexpr unsigned waterPhaseIdx = FluidSystem::waterPhaseIdx;
 
     static constexpr unsigned enableFoam = enableFoamV;
-    static constexpr bool enableVtkOutput = getPropValue<TypeTag, Properties::EnableVtkOutput>();
 
     static constexpr unsigned numEq = getPropValue<TypeTag, Properties::NumEq>();
     static constexpr unsigned numPhases = FluidSystem::numPhases;
@@ -188,7 +187,7 @@ public:
                                       Simulator&)
     {
         if constexpr (enableFoam) {
-            if (enableVtkOutput) {
+            if (Parameters::get<TypeTag, Properties::EnableVtkOutput>()) {
                 OpmLog::warning("VTK output requested, currently unsupported by the foam module.");
             }
         }

--- a/tests/problems/co2ptflashproblem.hh
+++ b/tests/problems/co2ptflashproblem.hh
@@ -337,7 +337,6 @@ class CO2PTProblem : public GetPropType<TypeTag, Properties::BaseProblem>
     enum { numComponents = getPropValue<TypeTag, Properties::NumComponents>() };
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
-    enum { enableGravity = getPropValue<TypeTag, Properties::EnableGravity>() };
 
     using GlobalPosition = Dune::FieldVector<CoordScalar, dimWorld>;
     using DimMatrix = Dune::FieldMatrix<Scalar, dimWorld, dimWorld>;


### PR DESCRIPTION
It makes no sense to use run-time parameters as properties, it only obtains the default values, not possible runtime values.