### PR TITLE
Start separating (compile time) Properties from (runtime) Parameters

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -241,6 +241,7 @@ list (APPEND PUBLIC_HEADER_FILES
              opm/models/utils/timer.hh
              opm/models/utils/signum.hh
              opm/models/utils/genericguard.hh
+             opm/models/utils/basicparameters.hh
              opm/models/utils/basicproperties.hh
              opm/simulators/linalg/ilufirstelement.hh
              opm/simulators/linalg/parallelistlbackend.hh

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -128,6 +128,7 @@ list (APPEND PUBLIC_HEADER_FILES
              opm/models/discretization/common/fvbaseboundarycontext.hh
              opm/models/discretization/common/fvbaseadlocallinearizer.hh
              opm/models/discretization/common/fvbaseconstraints.hh
+             opm/models/discretization/common/fvbaseparameters.hh
              opm/models/discretization/common/fvbaseproperties.hh
              opm/models/discretization/common/fvbaseextensivequantities.hh
              opm/models/discretization/common/fvbaselinearizer.hh

--- a/opm/models/blackoil/blackoilfoammodules.hh
+++ b/opm/models/blackoil/blackoilfoammodules.hh
@@ -30,9 +30,9 @@
 
 #include "blackoilproperties.hh"
 
-#include <opm/common/OpmLog/OpmLog.hpp>
+#include <dune/common/fvector.hh>
 
-#include <opm/models/blackoil/blackoilfoamparams.hh>
+#include <opm/common/OpmLog/OpmLog.hpp>
 
 #if HAVE_ECL_INPUT
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
@@ -40,10 +40,12 @@
 #include <opm/input/eclipse/EclipseState/Tables/FoammobTable.hpp>
 #endif
 
-#include <dune/common/fvector.hh>
+#include <opm/models/blackoil/blackoilfoamparams.hh>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+#include <opm/models/discretization/common/fvbaseproperties.hh>
 
 #include <string>
-#include <math.h>
 
 namespace Opm {
 
@@ -187,7 +189,7 @@ public:
                                       Simulator&)
     {
         if constexpr (enableFoam) {
-            if (Parameters::get<TypeTag, Properties::EnableVtkOutput>()) {
+            if (Parameters::get<TypeTag, Parameters::EnableVtkOutput>()) {
                 OpmLog::warning("VTK output requested, currently unsupported by the foam module.");
             }
         }

--- a/opm/models/common/multiphasebaseproblem.hh
+++ b/opm/models/common/multiphasebaseproblem.hh
@@ -28,20 +28,22 @@
 #ifndef EWOMS_MULTI_PHASE_BASE_PROBLEM_HH
 #define EWOMS_MULTI_PHASE_BASE_PROBLEM_HH
 
-#include "multiphasebaseproperties.hh"
+#include <dune/common/fvector.hh>
+#include <dune/common/fmatrix.hh>
 
-#include <opm/models/common/directionalmobility.hh>
-#include <opm/models/discretization/common/fvbaseproblem.hh>
-#include <opm/models/discretization/common/fvbaseproperties.hh>
+#include <dune/grid/common/partitionset.hh>
 
 #include <opm/material/fluidmatrixinteractions/NullMaterial.hpp>
 #include <opm/material/common/Means.hpp>
 #include <opm/material/densead/Evaluation.hpp>
 
-#include <opm/utility/CopyablePtr.hpp>
+#include <opm/models/common/directionalmobility.hh>
+#include <opm/models/common/multiphasebaseproperties.hh>
 
-#include <dune/common/fvector.hh>
-#include <dune/common/fmatrix.hh>
+#include <opm/models/discretization/common/fvbaseproblem.hh>
+#include <opm/models/discretization/common/fvbaseproperties.hh>
+
+#include <opm/utility/CopyablePtr.hpp>
 
 namespace Opm {
 /*!

--- a/opm/models/discretefracture/discretefracturemodel.hh
+++ b/opm/models/discretefracture/discretefracturemodel.hh
@@ -93,15 +93,20 @@ struct ExtensiveQuantities<TypeTag, TTag::DiscreteFractureModel>
 template<class TypeTag>
 struct UseTwoPointGradients<TypeTag, TTag::DiscreteFractureModel> { static constexpr bool value = true; };
 
+} // namespace Opm::Properties
+
+namespace Opm::Parameters {
+
 // The intensive quantity cache cannot be used by the discrete fracture model, because
 // the intensive quantities of a control degree of freedom are not identical to the
 // intensive quantities of the other intensive quantities of the same of the same degree
 // of freedom. This is because the fracture properties (volume, permeability, etc) are
 // specific for each...
 template<class TypeTag>
-struct EnableIntensiveQuantityCache<TypeTag, TTag::DiscreteFractureModel> { static constexpr bool value = false; };
+struct EnableIntensiveQuantityCache<TypeTag, Properties::TTag::DiscreteFractureModel>
+{ static constexpr bool value = false; };
 
-} // namespace Opm::Properties
+} // namespace Opm::Parameters
 
 namespace Opm {
 
@@ -132,7 +137,7 @@ public:
     DiscreteFractureModel(Simulator& simulator)
         : ParentType(simulator)
     {
-        if (Parameters::get<TypeTag, Properties::EnableIntensiveQuantityCache>()) {
+        if (Parameters::get<TypeTag, Parameters::EnableIntensiveQuantityCache>()) {
             throw std::runtime_error("The discrete fracture model does not work in conjunction "
                                      "with intensive quantities caching");
         }

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -217,11 +217,6 @@ struct VtkOutputFormat<TypeTag, TTag::FvBaseDiscretization> { static constexpr i
 template<class TypeTag>
 struct EnableConstraints<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = false; };
 
-// do not use thermodynamic hints by default. If you enable this, make sure to also
-// enable the intensive quantity cache above to avoid getting an exception...
-template<class TypeTag>
-struct EnableThermodynamicHints<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = false; };
-
 // if the deflection of the newton method is large, we do not need to solve the linear
 // approximation accurately. Assuming that the value for the current solution is quite
 // close to the final value, a reduction of 3 orders of magnitude in the defect should be
@@ -348,6 +343,12 @@ template<class TypeTag>
 struct EnableStorageCache<TypeTag, Properties::TTag::FvBaseDiscretization>
 { static constexpr bool value = false; };
 
+// do not use thermodynamic hints by default. If you enable this, make sure to also
+// enable the intensive quantity cache above to avoid getting an exception...
+template<class TypeTag>
+struct EnableThermodynamicHints<TypeTag, Properties::TTag::FvBaseDiscretization>
+{ static constexpr bool value = false; };
+
 } // namespace Opm::Parameters
 
 namespace Opm {
@@ -469,7 +470,7 @@ public:
         , enableGridAdaptation_(Parameters::get<TypeTag, Parameters::EnableGridAdaptation>() )
         , enableIntensiveQuantityCache_(Parameters::get<TypeTag, Parameters::EnableIntensiveQuantityCache>())
         , enableStorageCache_(Parameters::get<TypeTag, Parameters::EnableStorageCache>())
-        , enableThermodynamicHints_(Parameters::get<TypeTag, Properties::EnableThermodynamicHints>())
+        , enableThermodynamicHints_(Parameters::get<TypeTag, Parameters::EnableThermodynamicHints>())
     {
         bool isEcfv = std::is_same<Discretization, EcfvDiscretization<TypeTag> >::value;
         if (enableGridAdaptation_ && !isEcfv)
@@ -527,7 +528,7 @@ public:
             ("Enable adaptive grid refinement/coarsening");
         Parameters::registerParam<TypeTag, Parameters::EnableVtkOutput>
             ("Global switch for turning on writing VTK files");
-        Parameters::registerParam<TypeTag, Properties::EnableThermodynamicHints>
+        Parameters::registerParam<TypeTag, Parameters::EnableThermodynamicHints>
             ("Enable thermodynamic hints");
         Parameters::registerParam<TypeTag, Parameters::EnableIntensiveQuantityCache>
             ("Turn on caching of intensive quantities");

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -221,13 +221,6 @@ struct EnableStorageCache<TypeTag, TTag::FvBaseDiscretization> { static constexp
 template<class TypeTag>
 struct EnableConstraints<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = false; };
 
-// by default, disable the intensive quantity cache. If the intensive quantities are
-// relatively cheap to calculate, the cache basically does not yield any performance
-// impact because of the intensive quantity cache will cause additional pressure on the
-// CPU caches...
-template<class TypeTag>
-struct EnableIntensiveQuantityCache<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = false; };
-
 // do not use thermodynamic hints by default. If you enable this, make sure to also
 // enable the intensive quantity cache above to avoid getting an exception...
 template<class TypeTag>
@@ -344,6 +337,14 @@ struct MaxTimeStepDivisions<TypeTag, Properties::TTag::FvBaseDiscretization>
 //! step size.
 template<class TypeTag>
 struct ContinueOnConvergenceError<TypeTag, Properties::TTag::FvBaseDiscretization>
+{ static constexpr bool value = false; };
+
+//! by default, disable the intensive quantity cache. If the intensive quantities are
+//! relatively cheap to calculate, the cache basically does not yield any performance
+//! impact because of the intensive quantity cache will cause additional pressure on the
+//! CPU caches...
+template<class TypeTag>
+struct EnableIntensiveQuantityCache<TypeTag, Properties::TTag::FvBaseDiscretization>
 { static constexpr bool value = false; };
 
 } // namespace Opm::Parameters
@@ -465,7 +466,7 @@ public:
         , localLinearizer_(ThreadManager::maxThreads())
         , linearizer_(new Linearizer())
         , enableGridAdaptation_(Parameters::get<TypeTag, Parameters::EnableGridAdaptation>() )
-        , enableIntensiveQuantityCache_(Parameters::get<TypeTag, Properties::EnableIntensiveQuantityCache>())
+        , enableIntensiveQuantityCache_(Parameters::get<TypeTag, Parameters::EnableIntensiveQuantityCache>())
         , enableStorageCache_(Parameters::get<TypeTag, Properties::EnableStorageCache>())
         , enableThermodynamicHints_(Parameters::get<TypeTag, Properties::EnableThermodynamicHints>())
     {
@@ -527,7 +528,7 @@ public:
             ("Global switch for turning on writing VTK files");
         Parameters::registerParam<TypeTag, Properties::EnableThermodynamicHints>
             ("Enable thermodynamic hints");
-        Parameters::registerParam<TypeTag, Properties::EnableIntensiveQuantityCache>
+        Parameters::registerParam<TypeTag, Parameters::EnableIntensiveQuantityCache>
             ("Turn on caching of intensive quantities");
         Parameters::registerParam<TypeTag, Properties::EnableStorageCache>
             ("Store previous storage terms and avoid re-calculating them.");

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -237,10 +237,6 @@ struct MinTimeStepSize<TypeTag, TTag::FvBaseDiscretization>
     static constexpr type value = 0.0;
 };
 
-//! Disable grid adaptation by default
-template<class TypeTag>
-struct EnableGridAdaptation<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = false; };
-
 //! By default, write the simulation output to the current working directory
 template<class TypeTag>
 struct OutputDir<TypeTag, TTag::FvBaseDiscretization> { static constexpr auto value = "."; };
@@ -340,6 +336,11 @@ namespace Opm::Parameters {
 template<class TypeTag>
 struct ThreadsPerProcess<TypeTag, Properties::TTag::FvBaseDiscretization>
 { static constexpr int value = 1; };
+
+//! Disable grid adaptation by default
+template<class TypeTag>
+struct EnableGridAdaptation<TypeTag, Properties::TTag::FvBaseDiscretization>
+{ static constexpr bool value = false; };
 
 } // namespace Opm::Parameters
 
@@ -459,7 +460,7 @@ public:
         , newtonMethod_(simulator)
         , localLinearizer_(ThreadManager::maxThreads())
         , linearizer_(new Linearizer())
-        , enableGridAdaptation_(Parameters::get<TypeTag, Properties::EnableGridAdaptation>() )
+        , enableGridAdaptation_(Parameters::get<TypeTag, Parameters::EnableGridAdaptation>() )
         , enableIntensiveQuantityCache_(Parameters::get<TypeTag, Properties::EnableIntensiveQuantityCache>())
         , enableStorageCache_(Parameters::get<TypeTag, Properties::EnableStorageCache>())
         , enableThermodynamicHints_(Parameters::get<TypeTag, Properties::EnableThermodynamicHints>())
@@ -516,7 +517,7 @@ public:
         // register runtime parameters of the output modules
         VtkPrimaryVarsModule<TypeTag>::registerParameters();
 
-        Parameters::registerParam<TypeTag, Properties::EnableGridAdaptation>
+        Parameters::registerParam<TypeTag, Parameters::EnableGridAdaptation>
             ("Enable adaptive grid refinement/coarsening");
         Parameters::registerParam<TypeTag, Properties::EnableVtkOutput>
             ("Global switch for turning on writing VTK files");

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -213,10 +213,6 @@ struct Linearizer<TypeTag, TTag::FvBaseDiscretization> { using type = FvBaseLine
 template<class TypeTag>
 struct VtkOutputFormat<TypeTag, TTag::FvBaseDiscretization> { static constexpr int value = Dune::VTK::ascii; };
 
-// disable caching the storage term by default
-template<class TypeTag>
-struct EnableStorageCache<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = false; };
-
 // disable constraints by default
 template<class TypeTag>
 struct EnableConstraints<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = false; };
@@ -347,6 +343,11 @@ template<class TypeTag>
 struct EnableIntensiveQuantityCache<TypeTag, Properties::TTag::FvBaseDiscretization>
 { static constexpr bool value = false; };
 
+// disable caching the storage term by default
+template<class TypeTag>
+struct EnableStorageCache<TypeTag, Properties::TTag::FvBaseDiscretization>
+{ static constexpr bool value = false; };
+
 } // namespace Opm::Parameters
 
 namespace Opm {
@@ -467,7 +468,7 @@ public:
         , linearizer_(new Linearizer())
         , enableGridAdaptation_(Parameters::get<TypeTag, Parameters::EnableGridAdaptation>() )
         , enableIntensiveQuantityCache_(Parameters::get<TypeTag, Parameters::EnableIntensiveQuantityCache>())
-        , enableStorageCache_(Parameters::get<TypeTag, Properties::EnableStorageCache>())
+        , enableStorageCache_(Parameters::get<TypeTag, Parameters::EnableStorageCache>())
         , enableThermodynamicHints_(Parameters::get<TypeTag, Properties::EnableThermodynamicHints>())
     {
         bool isEcfv = std::is_same<Discretization, EcfvDiscretization<TypeTag> >::value;
@@ -476,7 +477,7 @@ public:
                                         "element-centered finite volume discretization (is: "
                                         +Dune::className<Discretization>()+")");
 
-        enableStorageCache_ = Parameters::get<TypeTag, Properties::EnableStorageCache>();
+        enableStorageCache_ = Parameters::get<TypeTag, Parameters::EnableStorageCache>();
 
         PrimaryVariables::init();
         size_t numDof = asImp_().numGridDof();
@@ -530,7 +531,7 @@ public:
             ("Enable thermodynamic hints");
         Parameters::registerParam<TypeTag, Parameters::EnableIntensiveQuantityCache>
             ("Turn on caching of intensive quantities");
-        Parameters::registerParam<TypeTag, Properties::EnableStorageCache>
+        Parameters::registerParam<TypeTag, Parameters::EnableStorageCache>
             ("Store previous storage terms and avoid re-calculating them.");
         Parameters::registerParam<TypeTag, Parameters::OutputDir>
             ("The directory to which result files are written");

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -120,12 +120,6 @@ struct DiscExtensiveQuantities<TypeTag, TTag::FvBaseDiscretization> { using type
 template<class TypeTag>
 struct GradientCalculator<TypeTag, TTag::FvBaseDiscretization> { using type = FvBaseGradientCalculator<TypeTag>; };
 
-//! By default, do not continue with a non-converged solution instead of giving up
-//! if we encounter a time step size smaller than the minimum time
-//! step size.
-template<class TypeTag>
-struct ContinueOnConvergenceError<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = false; };
-
 /*!
  * \brief A vector of quanties, each for one equation.
  */
@@ -344,6 +338,13 @@ struct MinTimeStepSize<TypeTag, Properties::TTag::FvBaseDiscretization>
 template<class TypeTag>
 struct MaxTimeStepDivisions<TypeTag, Properties::TTag::FvBaseDiscretization>
 { static constexpr unsigned value = 10; };
+
+//! By default, do not continue with a non-converged solution instead of giving up
+//! if we encounter a time step size smaller than the minimum time
+//! step size.
+template<class TypeTag>
+struct ContinueOnConvergenceError<TypeTag, Properties::TTag::FvBaseDiscretization>
+{ static constexpr bool value = false; };
 
 } // namespace Opm::Parameters
 

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -237,10 +237,6 @@ struct MinTimeStepSize<TypeTag, TTag::FvBaseDiscretization>
     static constexpr type value = 0.0;
 };
 
-//! Enable the VTK output by default
-template<class TypeTag>
-struct EnableVtkOutput<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = true; };
-
 //! By default, write the VTK output to asynchronously to disk
 //!
 //! This has only an effect if EnableVtkOutput is true
@@ -342,6 +338,11 @@ struct EnableGridAdaptation<TypeTag, Properties::TTag::FvBaseDiscretization>
 template<class TypeTag>
 struct OutputDir<TypeTag, Properties::TTag::FvBaseDiscretization>
 { static constexpr auto value = "."; };
+
+//! Enable the VTK output by default
+template<class TypeTag>
+struct EnableVtkOutput<TypeTag, Properties::TTag::FvBaseDiscretization>
+{ static constexpr bool value = true; };
 
 } // namespace Opm::Parameters
 
@@ -520,7 +521,7 @@ public:
 
         Parameters::registerParam<TypeTag, Parameters::EnableGridAdaptation>
             ("Enable adaptive grid refinement/coarsening");
-        Parameters::registerParam<TypeTag, Properties::EnableVtkOutput>
+        Parameters::registerParam<TypeTag, Parameters::EnableVtkOutput>
             ("Global switch for turning on writing VTK files");
         Parameters::registerParam<TypeTag, Properties::EnableThermodynamicHints>
             ("Enable thermodynamic hints");

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -237,12 +237,6 @@ struct MinTimeStepSize<TypeTag, TTag::FvBaseDiscretization>
     static constexpr type value = 0.0;
 };
 
-//! By default, write the VTK output to asynchronously to disk
-//!
-//! This has only an effect if EnableVtkOutput is true
-template<class TypeTag>
-struct EnableAsyncVtkOutput<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = true; };
-
 //! Set the format of the VTK output to ASCII by default
 template<class TypeTag>
 struct VtkOutputFormat<TypeTag, TTag::FvBaseDiscretization> { static constexpr int value = Dune::VTK::ascii; };
@@ -342,6 +336,13 @@ struct OutputDir<TypeTag, Properties::TTag::FvBaseDiscretization>
 //! Enable the VTK output by default
 template<class TypeTag>
 struct EnableVtkOutput<TypeTag, Properties::TTag::FvBaseDiscretization>
+{ static constexpr bool value = true; };
+
+//! By default, write the VTK output to asynchronously to disk
+//!
+//! This has only an effect if EnableVtkOutput is true
+template<class TypeTag>
+struct EnableAsyncVtkOutput<TypeTag, Properties::TTag::FvBaseDiscretization>
 { static constexpr bool value = true; };
 
 } // namespace Opm::Parameters

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -221,14 +221,6 @@ struct UseLinearizationLock<TypeTag, TTag::FvBaseDiscretization> { static conste
 template<class TypeTag>
 struct Linearizer<TypeTag, TTag::FvBaseDiscretization> { using type = FvBaseLinearizer<TypeTag>; };
 
-//! use an unlimited time step size by default
-template<class TypeTag>
-struct MaxTimeStepSize<TypeTag, TTag::FvBaseDiscretization>
-{
-    using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = std::numeric_limits<type>::infinity();
-};
-
 //! By default, accept any time step larger than zero
 template<class TypeTag>
 struct MinTimeStepSize<TypeTag, TTag::FvBaseDiscretization>
@@ -344,6 +336,14 @@ struct EnableVtkOutput<TypeTag, Properties::TTag::FvBaseDiscretization>
 template<class TypeTag>
 struct EnableAsyncVtkOutput<TypeTag, Properties::TTag::FvBaseDiscretization>
 { static constexpr bool value = true; };
+
+//! use an unlimited time step size by default
+template<class TypeTag>
+struct MaxTimeStepSize<TypeTag, Properties::TTag::FvBaseDiscretization>
+{
+    using type = GetPropType<TypeTag, Properties::Scalar>;
+    static constexpr type value = std::numeric_limits<type>::infinity();
+};
 
 } // namespace Opm::Parameters
 

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -221,14 +221,6 @@ struct UseLinearizationLock<TypeTag, TTag::FvBaseDiscretization> { static conste
 template<class TypeTag>
 struct Linearizer<TypeTag, TTag::FvBaseDiscretization> { using type = FvBaseLinearizer<TypeTag>; };
 
-//! By default, accept any time step larger than zero
-template<class TypeTag>
-struct MinTimeStepSize<TypeTag, TTag::FvBaseDiscretization>
-{
-    using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 0.0;
-};
-
 //! Set the format of the VTK output to ASCII by default
 template<class TypeTag>
 struct VtkOutputFormat<TypeTag, TTag::FvBaseDiscretization> { static constexpr int value = Dune::VTK::ascii; };
@@ -343,6 +335,14 @@ struct MaxTimeStepSize<TypeTag, Properties::TTag::FvBaseDiscretization>
 {
     using type = GetPropType<TypeTag, Properties::Scalar>;
     static constexpr type value = std::numeric_limits<type>::infinity();
+};
+
+//! By default, accept any time step larger than zero
+template<class TypeTag>
+struct MinTimeStepSize<TypeTag, Properties::TTag::FvBaseDiscretization>
+{
+    using type = GetPropType<TypeTag, Properties::Scalar>;
+    static constexpr type value = 0.0;
 };
 
 } // namespace Opm::Parameters

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -120,12 +120,6 @@ struct DiscExtensiveQuantities<TypeTag, TTag::FvBaseDiscretization> { using type
 template<class TypeTag>
 struct GradientCalculator<TypeTag, TTag::FvBaseDiscretization> { using type = FvBaseGradientCalculator<TypeTag>; };
 
-//! The maximum allowed number of timestep divisions for the
-//! Newton solver
-template<class TypeTag>
-struct MaxTimeStepDivisions<TypeTag, TTag::FvBaseDiscretization> { static constexpr unsigned value = 10; };
-
-
 //! By default, do not continue with a non-converged solution instead of giving up
 //! if we encounter a time step size smaller than the minimum time
 //! step size.
@@ -344,6 +338,12 @@ struct MinTimeStepSize<TypeTag, Properties::TTag::FvBaseDiscretization>
     using type = GetPropType<TypeTag, Properties::Scalar>;
     static constexpr type value = 0.0;
 };
+
+//! The maximum allowed number of timestep divisions for the
+//! Newton solver
+template<class TypeTag>
+struct MaxTimeStepDivisions<TypeTag, Properties::TTag::FvBaseDiscretization>
+{ static constexpr unsigned value = 10; };
 
 } // namespace Opm::Parameters
 

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -237,10 +237,6 @@ struct MinTimeStepSize<TypeTag, TTag::FvBaseDiscretization>
     static constexpr type value = 0.0;
 };
 
-//! By default, write the simulation output to the current working directory
-template<class TypeTag>
-struct OutputDir<TypeTag, TTag::FvBaseDiscretization> { static constexpr auto value = "."; };
-
 //! Enable the VTK output by default
 template<class TypeTag>
 struct EnableVtkOutput<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = true; };
@@ -341,6 +337,11 @@ struct ThreadsPerProcess<TypeTag, Properties::TTag::FvBaseDiscretization>
 template<class TypeTag>
 struct EnableGridAdaptation<TypeTag, Properties::TTag::FvBaseDiscretization>
 { static constexpr bool value = false; };
+
+//! By default, write the simulation output to the current working directory
+template<class TypeTag>
+struct OutputDir<TypeTag, Properties::TTag::FvBaseDiscretization>
+{ static constexpr auto value = "."; };
 
 } // namespace Opm::Parameters
 
@@ -527,7 +528,7 @@ public:
             ("Turn on caching of intensive quantities");
         Parameters::registerParam<TypeTag, Properties::EnableStorageCache>
             ("Store previous storage terms and avoid re-calculating them.");
-        Parameters::registerParam<TypeTag, Properties::OutputDir>
+        Parameters::registerParam<TypeTag, Parameters::OutputDir>
             ("The directory to which result files are written");
     }
 

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -213,8 +213,6 @@ struct ConstraintsContext<TypeTag, TTag::FvBaseDiscretization> { using type = Fv
 template<class TypeTag>
 struct ThreadManager<TypeTag, TTag::FvBaseDiscretization> { using type = ::Opm::ThreadManager<TypeTag>; };
 template<class TypeTag>
-struct ThreadsPerProcess<TypeTag, TTag::FvBaseDiscretization> { static constexpr int value = 1; };
-template<class TypeTag>
 struct UseLinearizationLock<TypeTag, TTag::FvBaseDiscretization> { static constexpr bool value = true; };
 
 /*!
@@ -336,6 +334,14 @@ struct DiscreteFunction<TypeTag, TTag::FvBaseDiscretization> {
 #endif
 
 } // namespace Opm::Properties
+
+namespace Opm::Parameters {
+
+template<class TypeTag>
+struct ThreadsPerProcess<TypeTag, Properties::TTag::FvBaseDiscretization>
+{ static constexpr int value = 1; };
+
+} // namespace Opm::Parameters
 
 namespace Opm {
 

--- a/opm/models/discretization/common/fvbaseelementcontext.hh
+++ b/opm/models/discretization/common/fvbaseelementcontext.hh
@@ -30,10 +30,12 @@
 
 #include "fvbaseproperties.hh"
 
-#include <opm/models/discretization/common/linearizationtype.hh>
-#include <opm/models/utils/alignedallocator.hh>
-
 #include <dune/common/fvector.hh>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+#include <opm/models/discretization/common/linearizationtype.hh>
+
+#include <opm/models/utils/alignedallocator.hh>
 
 #include <vector>
 
@@ -95,7 +97,7 @@ public:
     {
         // remember the simulator object
         simulatorPtr_ = &simulator;
-        enableStorageCache_ = Parameters::get<TypeTag, Properties::EnableStorageCache>();
+        enableStorageCache_ = Parameters::get<TypeTag, Parameters::EnableStorageCache>();
         stashedDofIdx_ = -1;
         focusDofIdx_ = -1;
     }

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -73,6 +73,14 @@ struct EnableVtkOutput { using type = Properties::UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct EnableAsyncVtkOutput { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief Specify the maximum size of a time integration [s].
+ *
+ * The default is to not limit the step size.
+ */
+template<class TypeTag, class MyTypeTag>
+struct MaxTimeStepSize { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -1,0 +1,42 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \ingroup FiniteVolumeDiscretizations
+ *
+ * \brief Declare the properties used by the infrastructure code of
+ *        the finite volume discretizations.
+ */
+#ifndef EWOMS_FV_BASE_PARAMETERS_HH
+#define EWOMS_FV_BASE_PARAMETERS_HH
+
+#include <opm/models/utils/propertysystem.hh>
+
+namespace Opm::Parameters {
+
+template<class TypeTag, class MyTypeTag>
+struct ThreadsPerProcess { using type = Properties::UndefinedProperty; };
+
+} // namespace Opm::Parameters
+
+#endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -52,6 +52,15 @@ struct EnableGridAdaptation { using type = Properties::UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct OutputDir { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief Global switch to enable or disable the writing of VTK output files
+ *
+ * If writing VTK files is disabled, then the WriteVtk$FOO options do
+ * not have any effect...
+ */
+template<class TypeTag, class MyTypeTag>
+struct EnableVtkOutput { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -46,6 +46,12 @@ struct ThreadsPerProcess { using type = Properties::UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct EnableGridAdaptation { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief The directory to which simulation output ought to be written to.
+ */
+template<class TypeTag, class MyTypeTag>
+struct OutputDir { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -37,6 +37,15 @@ namespace Opm::Parameters {
 template<class TypeTag, class MyTypeTag>
 struct ThreadsPerProcess { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief Switch to enable or disable grid adaptation
+ *
+ * Currently grid adaptation requires the presence of the dune-FEM module. If it is not
+ * available and grid adaptation is enabled, an exception is thrown.
+ */
+template<class TypeTag, class MyTypeTag>
+struct EnableGridAdaptation { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -96,6 +96,14 @@ struct MinTimeStepSize { using type = Properties::UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct MaxTimeStepDivisions { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief Continue with a non-converged solution instead of giving up
+ *        if we encounter a time step size smaller than the minimum time
+ *        step size.
+ */
+template<class TypeTag, class MyTypeTag>
+struct ContinueOnConvergenceError { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -89,6 +89,13 @@ struct MaxTimeStepSize { using type = Properties::UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct MinTimeStepSize { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief The maximum allowed number of timestep divisions for the
+ *        Newton solver.
+ */
+template<class TypeTag, class MyTypeTag>
+struct MaxTimeStepDivisions { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -104,6 +104,18 @@ struct MaxTimeStepDivisions { using type = Properties::UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct ContinueOnConvergenceError { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief Specify whether all intensive quantities for the grid should be
+ *        cached in the discretization.
+ *
+ * This potentially reduces the CPU time, but comes at the cost of
+ * higher memory consumption. In turn, the higher memory requirements
+ * may cause the simulation to exhibit worse cache coherence behavior
+ * which eats some of the computational benefits again.
+ */
+template<class TypeTag, class MyTypeTag>
+struct EnableIntensiveQuantityCache { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -116,6 +116,15 @@ struct ContinueOnConvergenceError { using type = Properties::UndefinedProperty; 
 template<class TypeTag, class MyTypeTag>
 struct EnableIntensiveQuantityCache { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief Specify whether the storage terms for previous solutions should be cached.
+ *
+ * This potentially reduces the CPU time, but comes at the cost of higher memory
+ * consumption.
+ */
+template<class TypeTag, class MyTypeTag>
+struct EnableStorageCache { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -125,6 +125,17 @@ struct EnableIntensiveQuantityCache { using type = Properties::UndefinedProperty
 template<class TypeTag, class MyTypeTag>
 struct EnableStorageCache { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief Specify whether to use the already calculated solutions as
+ *        starting values of the intensive quantities.
+ *
+ * This only makes sense if the calculation of the intensive quantities is
+ * very expensive (e.g. for non-linear fugacity functions where the
+ * solver converges faster).
+ */
+template<class TypeTag, class MyTypeTag>
+struct EnableThermodynamicHints { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -61,6 +61,18 @@ struct OutputDir { using type = Properties::UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct EnableVtkOutput { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief Determines if the VTK output is written to disk asynchronously
+ *
+ * I.e. written to disk using a separate thread. This has only an effect if
+ * EnableVtkOutput is true and if the simulation is run sequentially. The reasons for
+ * this not being used for MPI-parallel simulations are that Dune's VTK output code does
+ * not support multi-threaded multi-process VTK output and even if it would, the result
+ * would be slower than when using synchronous output.
+ */
+template<class TypeTag, class MyTypeTag>
+struct EnableAsyncVtkOutput { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -81,6 +81,14 @@ struct EnableAsyncVtkOutput { using type = Properties::UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct MaxTimeStepSize { using type = Properties::UndefinedProperty; };
 
+/*!
+ * \brief Specify the minimal size of a time integration [s].
+ *
+ * The default is to not limit the step size.
+ */
+template<class TypeTag, class MyTypeTag>
+struct MinTimeStepSize { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm::Parameters
 
 #endif

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -171,7 +171,7 @@ public:
         Model::registerParameters();
         Parameters::registerParam<TypeTag, Parameters::MaxTimeStepSize>
             ("The maximum size to which all time steps are limited to [s]");
-        Parameters::registerParam<TypeTag, Properties::MinTimeStepSize>
+        Parameters::registerParam<TypeTag, Parameters::MinTimeStepSize>
             ("The minimum size to which all time steps are limited to [s]");
         Parameters::registerParam<TypeTag, Properties::MaxTimeStepDivisions>
             ("The maximum number of divisions by two of the timestep size "
@@ -560,7 +560,7 @@ public:
      * \brief Returns the minimum allowable size of a time step.
      */
     Scalar minTimeStepSize() const
-    { return Parameters::get<TypeTag, Properties::MinTimeStepSize>(); }
+    { return Parameters::get<TypeTag, Parameters::MinTimeStepSize>(); }
 
     /*!
      * \brief Returns the maximum number of subsequent failures for the time integration

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -142,7 +142,7 @@ public:
         if (enableVtkOutput_()) {
             bool asyncVtkOutput =
                 simulator_.gridView().comm().size() == 1 &&
-                Parameters::get<TypeTag, Properties::EnableAsyncVtkOutput>();
+                Parameters::get<TypeTag, Parameters::EnableAsyncVtkOutput>();
 
             // asynchonous VTK output currently does not work in conjunction with grid
             // adaptivity because the async-IO code assumes that the grid stays
@@ -176,7 +176,7 @@ public:
         Parameters::registerParam<TypeTag, Properties::MaxTimeStepDivisions>
             ("The maximum number of divisions by two of the timestep size "
              "before the simulation bails out");
-        Parameters::registerParam<TypeTag, Properties::EnableAsyncVtkOutput>
+        Parameters::registerParam<TypeTag, Parameters::EnableAsyncVtkOutput>
             ("Dispatch a separate thread to write the VTK output");
         Parameters::registerParam<TypeTag, Properties::ContinueOnConvergenceError>
             ("Continue with a non-converged solution instead of giving up "

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -204,7 +204,7 @@ public:
      */
     std::string outputDir() const
     {
-        std::string outputDir = Parameters::get<TypeTag, Properties::OutputDir>();
+        std::string outputDir = Parameters::get<TypeTag, Parameters::OutputDir>();
 
         if (outputDir.empty())
             outputDir = ".";

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -28,7 +28,8 @@
 #ifndef EWOMS_FV_BASE_PROBLEM_HH
 #define EWOMS_FV_BASE_PROBLEM_HH
 
-#include "fvbaseproperties.hh"
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+#include <opm/models/discretization/common/fvbaseproperties.hh>
 
 #include <opm/models/io/vtkmultiwriter.hh>
 #include <opm/models/io/restart.hh>
@@ -146,7 +147,7 @@ public:
             // asynchonous VTK output currently does not work in conjunction with grid
             // adaptivity because the async-IO code assumes that the grid stays
             // constant. complain about that case.
-            bool enableGridAdaptation = Parameters::get<TypeTag, Properties::EnableGridAdaptation>();
+            bool enableGridAdaptation = Parameters::get<TypeTag, Parameters::EnableGridAdaptation>();
             if (asyncVtkOutput && enableGridAdaptation)
                 throw std::runtime_error("Asynchronous VTK output currently cannot be used "
                                          "at the same time as grid adaptivity");

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -812,7 +812,7 @@ protected:
 
 private:
     bool enableVtkOutput_() const
-    { return Parameters::get<TypeTag, Properties::EnableVtkOutput>(); }
+    { return Parameters::get<TypeTag, Parameters::EnableVtkOutput>(); }
 
     //! Returns the implementation of the problem (i.e. static polymorphism)
     Implementation& asImp_()

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -173,7 +173,7 @@ public:
             ("The maximum size to which all time steps are limited to [s]");
         Parameters::registerParam<TypeTag, Parameters::MinTimeStepSize>
             ("The minimum size to which all time steps are limited to [s]");
-        Parameters::registerParam<TypeTag, Properties::MaxTimeStepDivisions>
+        Parameters::registerParam<TypeTag, Parameters::MaxTimeStepDivisions>
             ("The maximum number of divisions by two of the timestep size "
              "before the simulation bails out");
         Parameters::registerParam<TypeTag, Parameters::EnableAsyncVtkOutput>
@@ -567,7 +567,7 @@ public:
      *        before giving up.
      */
     unsigned maxTimeIntegrationFailures() const
-    { return Parameters::get<TypeTag, Properties::MaxTimeStepDivisions>(); }
+    { return Parameters::get<TypeTag, Parameters::MaxTimeStepDivisions>(); }
 
     /*!
      * \brief Returns if we should continue with a non-converged solution instead of

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -169,7 +169,7 @@ public:
     static void registerParameters()
     {
         Model::registerParameters();
-        Parameters::registerParam<TypeTag, Properties::MaxTimeStepSize>
+        Parameters::registerParam<TypeTag, Parameters::MaxTimeStepSize>
             ("The maximum size to which all time steps are limited to [s]");
         Parameters::registerParam<TypeTag, Properties::MinTimeStepSize>
             ("The minimum size to which all time steps are limited to [s]");
@@ -593,7 +593,7 @@ public:
         if (nextTimeStepSize_ > 0.0)
             return nextTimeStepSize_;
 
-        Scalar dtNext = std::min(Parameters::get<TypeTag, Properties::MaxTimeStepSize>(),
+        Scalar dtNext = std::min(Parameters::get<TypeTag, Parameters::MaxTimeStepSize>(),
                                  newtonMethod().suggestTimeStepSize(simulator().timeStepSize()));
 
         if (dtNext < simulator().maxTimeStepSize()

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -178,7 +178,7 @@ public:
              "before the simulation bails out");
         Parameters::registerParam<TypeTag, Parameters::EnableAsyncVtkOutput>
             ("Dispatch a separate thread to write the VTK output");
-        Parameters::registerParam<TypeTag, Properties::ContinueOnConvergenceError>
+        Parameters::registerParam<TypeTag, Parameters::ContinueOnConvergenceError>
             ("Continue with a non-converged solution instead of giving up "
              "if we encounter a time step size smaller than the minimum time "
              "step size.");
@@ -575,7 +575,7 @@ public:
      *        step size.
      */
     bool continueOnConvergenceError() const
-    { return Parameters::get<TypeTag, Properties::ContinueOnConvergenceError>(); }
+    { return Parameters::get<TypeTag, Parameters::ContinueOnConvergenceError>(); }
 
     /*!
      * \brief Impose the next time step size to be used externally.

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -216,15 +216,6 @@ template<class TypeTag, class MyTypeTag>
 struct EnableConstraints { using type = UndefinedProperty; };
 
 /*!
- * \brief Specify whether the storage terms for previous solutions should be cached.
- *
- * This potentially reduces the CPU time, but comes at the cost of higher memory
- * consumption.
- */
-template<class TypeTag, class MyTypeTag>
-struct EnableStorageCache { using type = UndefinedProperty; };
-
-/*!
  * \brief Specify whether to use the already calculated solutions as
  *        starting values of the intensive quantities.
  *

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -50,25 +50,10 @@ struct FvBaseDiscretization
 } // namespace TTag
 
 
-//! set the splices for the finite volume discretizations
 template<class TypeTag, class MyTypeTag>
 struct LinearSolverSplice { using type = UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct LocalLinearizerSplice { using type = UndefinedProperty; };
-template<class TypeTag>
-struct Splices<TypeTag, TTag::FvBaseDiscretization>
-{
-    using type = std::tuple<GetSplicePropType<TypeTag, TTag::FvBaseDiscretization, Properties::LinearSolverSplice>,
-                            GetSplicePropType<TypeTag, TTag::FvBaseDiscretization, Properties::LocalLinearizerSplice>>;
-};
-
-//! use a parallel BiCGStab linear solver by default
-template<class TypeTag>
-struct LinearSolverSplice<TypeTag, TTag::FvBaseDiscretization> { using type = TTag::ParallelBiCGStabLinearSolver; };
-
-//! by default, use finite differences to linearize the system of PDEs
-template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::FvBaseDiscretization> { using type = TTag::FiniteDifferenceLocalLinearizer; };
 
 /*!
  * \brief Representation of a function evaluation and all necessary derivatives with
@@ -255,6 +240,26 @@ struct UseVolumetricResidual { using type = UndefinedProperty; };
 //! Specify if experimental features should be enabled or not.
 template<class TypeTag, class MyTypeTag>
 struct EnableExperiments { using type = UndefinedProperty; };
+
+// Set defaults
+
+//! set the splices for the finite volume discretizations
+template<class TypeTag>
+struct Splices<TypeTag, TTag::FvBaseDiscretization>
+{
+    using type = std::tuple<GetSplicePropType<TypeTag, TTag::FvBaseDiscretization, Properties::LinearSolverSplice>,
+                            GetSplicePropType<TypeTag, TTag::FvBaseDiscretization, Properties::LocalLinearizerSplice>>;
+};
+
+//! use a parallel BiCGStab linear solver by default
+template<class TypeTag>
+struct LinearSolverSplice<TypeTag, TTag::FvBaseDiscretization>
+{ using type = TTag::ParallelBiCGStabLinearSolver; };
+
+//! by default, use finite differences to linearize the system of PDEs
+template<class TypeTag>
+struct LocalLinearizerSplice<TypeTag, TTag::FvBaseDiscretization>
+{ using type = TTag::FiniteDifferenceLocalLinearizer; };
 
 } // namespace Opm::Properties
 

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -200,15 +200,6 @@ struct UseLinearizationLock { using type = UndefinedProperty; };
 // high-level simulation control
 
 /*!
- * \brief Global switch to enable or disable the writing of VTK output files
- *
- * If writing VTK files is disabled, then the WriteVtk$FOO options do
- * not have any effect...
- */
-template<class TypeTag, class MyTypeTag>
-struct EnableVtkOutput { using type = UndefinedProperty; };
-
-/*!
  * \brief Determines if the VTK output is written to disk asynchronously
  *
  * I.e. written to disk using a separate thread. This has only an effect if

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -253,7 +253,6 @@ struct ExtensiveStorageTerm { using type = UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct UseVolumetricResidual { using type = UndefinedProperty; };
 
-
 //! Specify if experimental features should be enabled or not.
 template<class TypeTag, class MyTypeTag>
 struct EnableExperiments { using type = UndefinedProperty; };

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -216,14 +216,6 @@ template<class TypeTag, class MyTypeTag>
 struct EnableConstraints { using type = UndefinedProperty; };
 
 /*!
- * \brief Specify the minimal size of a time integration [s].
- *
- * The default is to not limit the step size.
- */
-template<class TypeTag, class MyTypeTag>
-struct MinTimeStepSize { using type = UndefinedProperty; };
-
-/*!
  * \brief The maximum allowed number of timestep divisions for the
  *        Newton solver.
  */

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -216,13 +216,6 @@ template<class TypeTag, class MyTypeTag>
 struct EnableConstraints { using type = UndefinedProperty; };
 
 /*!
- * \brief The maximum allowed number of timestep divisions for the
- *        Newton solver.
- */
-template<class TypeTag, class MyTypeTag>
-struct MaxTimeStepDivisions { using type = UndefinedProperty; };
-
-/*!
  * \brief Continue with a non-converged solution instead of giving up
  *        if we encounter a time step size smaller than the minimum time
  *        step size.

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -216,14 +216,6 @@ template<class TypeTag, class MyTypeTag>
 struct EnableConstraints { using type = UndefinedProperty; };
 
 /*!
- * \brief Specify the maximum size of a time integration [s].
- *
- * The default is to not limit the step size.
- */
-template<class TypeTag, class MyTypeTag>
-struct MaxTimeStepSize { using type = UndefinedProperty; };
-
-/*!
  * \brief Specify the minimal size of a time integration [s].
  *
  * The default is to not limit the step size.

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -200,12 +200,6 @@ struct UseLinearizationLock { using type = UndefinedProperty; };
 // high-level simulation control
 
 /*!
- * \brief The directory to which simulation output ought to be written to.
- */
-template<class TypeTag, class MyTypeTag>
-struct OutputDir { using type = UndefinedProperty; };
-
-/*!
  * \brief Global switch to enable or disable the writing of VTK output files
  *
  * If writing VTK files is disabled, then the WriteVtk$FOO options do

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -216,14 +216,6 @@ template<class TypeTag, class MyTypeTag>
 struct EnableConstraints { using type = UndefinedProperty; };
 
 /*!
- * \brief Continue with a non-converged solution instead of giving up
- *        if we encounter a time step size smaller than the minimum time
- *        step size.
- */
-template<class TypeTag, class MyTypeTag>
-struct ContinueOnConvergenceError { using type = UndefinedProperty; };
-
-/*!
  * \brief Specify whether all intensive quantities for the grid should be
  *        cached in the discretization.
  *

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -189,8 +189,6 @@ struct GridCommHandleFactory { using type = UndefinedProperty; };
  */
 template<class TypeTag, class MyTypeTag>
 struct ThreadManager { using type = UndefinedProperty; };
-template<class TypeTag, class MyTypeTag>
-struct ThreadsPerProcess { using type = UndefinedProperty; };
 
 //! use locking to prevent race conditions when linearizing the global system of
 //! equations in multi-threaded mode. (setting this property to true is always save, but

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -215,17 +215,6 @@ struct VtkOutputFormat { using type = UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct EnableConstraints { using type = UndefinedProperty; };
 
-/*!
- * \brief Specify whether to use the already calculated solutions as
- *        starting values of the intensive quantities.
- *
- * This only makes sense if the calculation of the intensive quantities is
- * very expensive (e.g. for non-linear fugacity functions where the
- * solver converges faster).
- */
-template<class TypeTag, class MyTypeTag>
-struct EnableThermodynamicHints { using type = UndefinedProperty; };
-
 // mappers from local to global DOF indices
 
 /*!

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -200,15 +200,6 @@ struct UseLinearizationLock { using type = UndefinedProperty; };
 // high-level simulation control
 
 /*!
- * \brief Switch to enable or disable grid adaptation
- *
- * Currently grid adaptation requires the presence of the dune-FEM module. If it is not
- * available and grid adaptation is enabled, an exception is thrown.
- */
-template<class TypeTag, class MyTypeTag>
-struct EnableGridAdaptation { using type = UndefinedProperty; };
-
-/*!
  * \brief The directory to which simulation output ought to be written to.
  */
 template<class TypeTag, class MyTypeTag>

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -216,18 +216,6 @@ template<class TypeTag, class MyTypeTag>
 struct EnableConstraints { using type = UndefinedProperty; };
 
 /*!
- * \brief Specify whether all intensive quantities for the grid should be
- *        cached in the discretization.
- *
- * This potentially reduces the CPU time, but comes at the cost of
- * higher memory consumption. In turn, the higher memory requirements
- * may cause the simulation to exhibit worse cache coherence behavior
- * which eats some of the computational benefits again.
- */
-template<class TypeTag, class MyTypeTag>
-struct EnableIntensiveQuantityCache { using type = UndefinedProperty; };
-
-/*!
  * \brief Specify whether the storage terms for previous solutions should be cached.
  *
  * This potentially reduces the CPU time, but comes at the cost of higher memory

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -31,7 +31,6 @@
 #define EWOMS_FV_BASE_PROPERTIES_HH
 
 #include <opm/models/utils/basicproperties.hh>
-#include <opm/models/io/dgfvanguard.hh>
 
 namespace Opm::Properties {
 
@@ -256,9 +255,6 @@ struct UseVolumetricResidual { using type = UndefinedProperty; };
 //! Specify if experimental features should be enabled or not.
 template<class TypeTag, class MyTypeTag>
 struct EnableExperiments { using type = UndefinedProperty; };
-
-template<class TypeTag>
-struct Vanguard<TypeTag, TTag::NumericModel> { using type = Opm::DgfVanguard<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -200,18 +200,6 @@ struct UseLinearizationLock { using type = UndefinedProperty; };
 // high-level simulation control
 
 /*!
- * \brief Determines if the VTK output is written to disk asynchronously
- *
- * I.e. written to disk using a separate thread. This has only an effect if
- * EnableVtkOutput is true and if the simulation is run sequentially. The reasons for
- * this not being used for MPI-parallel simulations are that Dune's VTK output code does
- * not support multi-threaded multi-process VTK output and even if it would, the result
- * would be slower than when using synchronous output.
- */
-template<class TypeTag, class MyTypeTag>
-struct EnableAsyncVtkOutput { using type = UndefinedProperty; };
-
-/*!
  * \brief Specify the format the VTK output is written to disk
  *
  * Possible values are:

--- a/opm/models/flash/flashmodel.hh
+++ b/opm/models/flash/flashmodel.hh
@@ -112,12 +112,6 @@ struct ExtensiveQuantities<TypeTag, TTag::FlashModel> { using type = Opm::FlashE
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlashModel> { using type = Opm::FlashIndices<TypeTag, /*PVIdx=*/0>; };
 
-// since thermodynamic hints are basically free if the cache for intensive quantities is
-// enabled, and this model usually shows quite a performance improvment if they are
-// enabled, let's enable them by default.
-template<class TypeTag>
-struct EnableThermodynamicHints<TypeTag, TTag::FlashModel> { static constexpr bool value = true; };
-
 // disable molecular diffusion by default
 template<class TypeTag>
 struct EnableDiffusion<TypeTag, TTag::FlashModel> { static constexpr bool value = false; };
@@ -134,6 +128,13 @@ namespace Opm::Parameters {
 // model, so let's try to minimize the number of required ones
 template<class TypeTag>
 struct EnableIntensiveQuantityCache<TypeTag, Properties::TTag::FlashModel>
+{ static constexpr bool value = true; };
+
+// since thermodynamic hints are basically free if the cache for intensive quantities is
+// enabled, and this model usually shows quite a performance improvment if they are
+// enabled, let's enable them by default.
+template<class TypeTag>
+struct EnableThermodynamicHints<TypeTag, Properties::TTag::FlashModel>
 { static constexpr bool value = true; };
 
 } // namespace Opm::Parameters

--- a/opm/models/flash/flashmodel.hh
+++ b/opm/models/flash/flashmodel.hh
@@ -112,11 +112,6 @@ struct ExtensiveQuantities<TypeTag, TTag::FlashModel> { using type = Opm::FlashE
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlashModel> { using type = Opm::FlashIndices<TypeTag, /*PVIdx=*/0>; };
 
-// The updates of intensive quantities tend to be _very_ expensive for this
-// model, so let's try to minimize the number of required ones
-template<class TypeTag>
-struct EnableIntensiveQuantityCache<TypeTag, TTag::FlashModel> { static constexpr bool value = true; };
-
 // since thermodynamic hints are basically free if the cache for intensive quantities is
 // enabled, and this model usually shows quite a performance improvment if they are
 // enabled, let's enable them by default.
@@ -132,6 +127,16 @@ template<class TypeTag>
 struct EnableEnergy<TypeTag, TTag::FlashModel> { static constexpr bool value = false; };
 
 } // namespace Opm::Properties
+
+namespace Opm::Parameters {
+
+// The updates of intensive quantities tend to be _very_ expensive for this
+// model, so let's try to minimize the number of required ones
+template<class TypeTag>
+struct EnableIntensiveQuantityCache<TypeTag, Properties::TTag::FlashModel>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Parameters
 
 namespace Opm {
 

--- a/opm/models/io/cubegridvanguard.hh
+++ b/opm/models/io/cubegridvanguard.hh
@@ -28,6 +28,7 @@
 #define EWOMS_CUBE_GRID_VANGUARD_HH
 
 #include <opm/models/io/basevanguard.hh>
+#include <opm/models/utils/basicparameters.hh>
 #include <opm/models/utils/basicproperties.hh>
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
@@ -66,7 +67,7 @@ public:
      */
     static void registerParameters()
     {
-        Parameters::registerParam<TypeTag, Properties::GridGlobalRefinements>
+        Parameters::registerParam<TypeTag, Parameters::GridGlobalRefinements>
             ("The number of global refinements of the grid "
              "executed after it was loaded");
         Parameters::registerParam<TypeTag, Properties::DomainSizeX>
@@ -111,7 +112,7 @@ public:
             cellRes[2] = Parameters::get<TypeTag, Properties::CellsZ>();
         }
 
-        unsigned numRefinements = Parameters::get<TypeTag, Properties::GridGlobalRefinements>();
+        unsigned numRefinements = Parameters::get<TypeTag, Parameters::GridGlobalRefinements>();
         cubeGrid_ = Dune::StructuredGridFactory<Grid>::createCubeGrid(lowerLeft, upperRight, cellRes);
         cubeGrid_->globalRefine(static_cast<int>(numRefinements));
 

--- a/opm/models/io/dgfvanguard.hh
+++ b/opm/models/io/dgfvanguard.hh
@@ -64,7 +64,7 @@ public:
     {
         Parameters::registerParam<TypeTag,Properties::GridFile>
             ("The file name of the DGF file to load");
-        Parameters::registerParam<TypeTag,Properties::GridGlobalRefinements>
+        Parameters::registerParam<TypeTag, Parameters::GridGlobalRefinements>
             ("The number of global refinements of the grid "
              "executed after it was loaded");
     }
@@ -76,7 +76,7 @@ public:
         : ParentType(simulator)
     {
         const std::string dgfFileName = Parameters::get<TypeTag, Properties::GridFile>();
-        unsigned numRefinments = Parameters::get<TypeTag, Properties::GridGlobalRefinements>();
+        unsigned numRefinments = Parameters::get<TypeTag, Parameters::GridGlobalRefinements>();
 
         {
             // create DGF GridPtr from a dgf file

--- a/opm/models/io/structuredgridvanguard.hh
+++ b/opm/models/io/structuredgridvanguard.hh
@@ -28,8 +28,11 @@
 #define EWOMS_STRUCTURED_GRID_VANGUARD_HH
 
 #include <opm/models/io/basevanguard.hh>
-#include <opm/models/utils/propertysystem.hh>
+
+#include <opm/models/utils/basicparameters.hh>
+#include <opm/models/utils/basicproperties.hh>
 #include <opm/models/utils/parametersystem.hh>
+#include <opm/models/utils/propertysystem.hh>
 
 #include <dune/grid/yaspgrid.hh>
 #include <dune/grid/io/file/dgfparser/dgfyasp.hh>
@@ -42,7 +45,6 @@
 #include <dune/common/fvector.hh>
 #include <dune/common/version.hh>
 
-#include <vector>
 #include <memory>
 
 namespace Opm {
@@ -106,7 +108,7 @@ public:
      */
     static void registerParameters()
     {
-        Parameters::registerParam<TypeTag, Properties::GridGlobalRefinements>
+        Parameters::registerParam<TypeTag, Parameters::GridGlobalRefinements>
             ("The number of global refinements of the grid "
              "executed after it was loaded");
         Parameters::registerParam<TypeTag, Properties::DomainSizeX>
@@ -165,7 +167,7 @@ public:
         // use DGF parser to create a grid from interval block
         gridPtr_.reset( Dune::GridPtr< Grid >( dgffile ).release() );
 
-        unsigned numRefinements = Parameters::get<TypeTag, Properties::GridGlobalRefinements>();
+        unsigned numRefinements = Parameters::get<TypeTag, Parameters::GridGlobalRefinements>();
         gridPtr_->globalRefine(static_cast<int>(numRefinements));
 
         this->finalizeInit_();

--- a/opm/models/io/vtkblackoilenergymodule.hh
+++ b/opm/models/io/vtkblackoilenergymodule.hh
@@ -27,18 +27,18 @@
 #ifndef EWOMS_VTK_BLACK_OIL_ENERGY_MODULE_HH
 #define EWOMS_VTK_BLACK_OIL_ENERGY_MODULE_HH
 
-#include <opm/material/densead/Math.hpp>
-
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
+
+#include <dune/common/fvector.hh>
+
+#include <opm/material/densead/Math.hpp>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
 
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/models/blackoil/blackoilproperties.hh>
-
-#include <dune/common/fvector.hh>
-
-#include <cstdio>
 
 namespace Opm::Properties {
 
@@ -130,7 +130,7 @@ public:
      */
     void allocBuffers()
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         if (!enableEnergy)
@@ -152,7 +152,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         if (!enableEnergy)

--- a/opm/models/io/vtkblackoilmicpmodule.hh
+++ b/opm/models/io/vtkblackoilmicpmodule.hh
@@ -27,18 +27,18 @@
 #ifndef EWOMS_VTK_BLACK_OIL_MICP_MODULE_HH
 #define EWOMS_VTK_BLACK_OIL_MICP_MODULE_HH
 
-#include <opm/material/densead/Math.hpp>
-
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
+
+#include <dune/common/fvector.hh>
+
+#include <opm/material/densead/Math.hpp>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
 
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/models/blackoil/blackoilproperties.hh>
-
-#include <dune/common/fvector.hh>
-
-#include <cstdio>
 
 namespace Opm::Properties {
 
@@ -134,7 +134,7 @@ public:
      */
     void allocBuffers()
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         if (!enableMICP)
@@ -158,7 +158,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         if (!enableMICP)

--- a/opm/models/io/vtkblackoilmodule.hh
+++ b/opm/models/io/vtkblackoilmodule.hh
@@ -27,18 +27,19 @@
 #ifndef EWOMS_VTK_BLACK_OIL_MODULE_HH
 #define EWOMS_VTK_BLACK_OIL_MODULE_HH
 
-#include <opm/material/densead/Math.hpp>
-
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
 
-#include <opm/models/utils/propertysystem.hh>
-#include <opm/models/utils/parametersystem.hh>
-#include <opm/models/blackoil/blackoilproperties.hh>
-
 #include <dune/common/fvector.hh>
 
-#include <cstdio>
+#include <opm/material/densead/Math.hpp>
+
+#include <opm/models/blackoil/blackoilproperties.hh>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
+#include <opm/models/utils/parametersystem.hh>
+#include <opm/models/utils/propertysystem.hh>
 
 namespace Opm::Properties {
 
@@ -216,7 +217,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         for (unsigned dofIdx = 0; dofIdx < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++dofIdx) {
@@ -424,9 +425,8 @@ private:
     ScalarBuffer primaryVarsMeaningPressure_;
     ScalarBuffer primaryVarsMeaningWater_;
     ScalarBuffer primaryVarsMeaningGas_;
-
-
 };
+
 } // namespace Opm
 
 #endif

--- a/opm/models/io/vtkblackoilpolymermodule.hh
+++ b/opm/models/io/vtkblackoilpolymermodule.hh
@@ -27,18 +27,18 @@
 #ifndef EWOMS_VTK_BLACK_OIL_POLYMER_MODULE_HH
 #define EWOMS_VTK_BLACK_OIL_POLYMER_MODULE_HH
 
-#include <opm/material/densead/Math.hpp>
-
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
+
+#include <dune/common/fvector.hh>
+
+#include <opm/material/densead/Math.hpp>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
 
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/models/blackoil/blackoilproperties.hh>
-
-#include <dune/common/fvector.hh>
-
-#include <cstdio>
 
 namespace Opm::Properties {
 
@@ -143,7 +143,7 @@ public:
      */
     void allocBuffers()
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         if (!enablePolymer)
@@ -169,7 +169,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         if (!enablePolymer)

--- a/opm/models/io/vtkblackoilsolventmodule.hh
+++ b/opm/models/io/vtkblackoilsolventmodule.hh
@@ -27,18 +27,18 @@
 #ifndef EWOMS_VTK_BLACK_OIL_SOLVENT_MODULE_HH
 #define EWOMS_VTK_BLACK_OIL_SOLVENT_MODULE_HH
 
-#include <opm/material/densead/Math.hpp>
-
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
+
+#include <dune/common/fvector.hh>
+
+#include <opm/material/densead/Math.hpp>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
 
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/models/blackoil/blackoilproperties.hh>
-
-#include <dune/common/fvector.hh>
-
-#include <cstdio>
 
 namespace Opm::Properties {
 
@@ -136,7 +136,7 @@ public:
      */
     void allocBuffers()
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         if (!enableSolvent)
@@ -160,7 +160,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         if (!enableSolvent)

--- a/opm/models/io/vtkcompositionmodule.hh
+++ b/opm/models/io/vtkcompositionmodule.hh
@@ -30,10 +30,12 @@
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
 
+#include <opm/material/common/MathToolbox.hpp>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
-
-#include <opm/material/common/MathToolbox.hpp>
 
 namespace Opm::Properties {
 
@@ -170,7 +172,7 @@ public:
     {
         using Toolbox = MathToolbox<Evaluation>;
 
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {

--- a/opm/models/io/vtkdiffusionmodule.hh
+++ b/opm/models/io/vtkdiffusionmodule.hh
@@ -31,11 +31,13 @@
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
 
-#include <opm/models/utils/propertysystem.hh>
-#include <opm/models/utils/parametersystem.hh>
-
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
+#include <opm/models/utils/propertysystem.hh>
+#include <opm/models/utils/parametersystem.hh>
 
 namespace Opm::Properties {
 
@@ -138,7 +140,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {

--- a/opm/models/io/vtkdiscretefracturemodule.hh
+++ b/opm/models/io/vtkdiscretefracturemodule.hh
@@ -30,15 +30,16 @@
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
 
+#include <dune/common/fvector.hh>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 
 #include <opm/material/common/Valgrind.hpp>
 
-#include <dune/common/fvector.hh>
-
 #include <cstdio>
-#include <string_view>
 
 namespace Opm::Properties {
 
@@ -190,7 +191,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         const auto& fractureMapper = elemCtx.simulator().vanguard().fractureMapper();

--- a/opm/models/io/vtkenergymodule.hh
+++ b/opm/models/io/vtkenergymodule.hh
@@ -30,6 +30,8 @@
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
 
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 
@@ -148,7 +150,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {

--- a/opm/models/io/vtkmultiphasemodule.hh
+++ b/opm/models/io/vtkmultiphasemodule.hh
@@ -30,16 +30,17 @@
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
 
-#include <opm/models/utils/propertysystem.hh>
-#include <opm/models/utils/parametersystem.hh>
-
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
+#include <opm/models/utils/propertysystem.hh>
+#include <opm/models/utils/parametersystem.hh>
 
 #include <dune/common/fvector.hh>
 
 #include <cstdio>
-#include <string_view>
 
 namespace Opm::Properties {
 
@@ -238,7 +239,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         const auto& problem = elemCtx.problem();

--- a/opm/models/io/vtkphasepresencemodule.hh
+++ b/opm/models/io/vtkphasepresencemodule.hh
@@ -30,6 +30,8 @@
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
 
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/models/utils/propertysystem.hh>
 
@@ -103,7 +105,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {

--- a/opm/models/io/vtkprimaryvarsmodule.hh
+++ b/opm/models/io/vtkprimaryvarsmodule.hh
@@ -27,6 +27,8 @@
 #ifndef EWOMS_VTK_PRIMARY_VARS_MODULE_HH
 #define EWOMS_VTK_PRIMARY_VARS_MODULE_HH
 
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
 #include <opm/models/io/baseoutputmodule.hh>
 #include <opm/models/io/vtkmultiwriter.hh>
 
@@ -122,7 +124,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         const auto& elementMapper = elemCtx.model().elementMapper();

--- a/opm/models/io/vtkptflashmodule.hh
+++ b/opm/models/io/vtkptflashmodule.hh
@@ -30,10 +30,12 @@
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
 
+#include <opm/material/common/MathToolbox.hpp>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
-
-#include <opm/material/common/MathToolbox.hpp>
 
 namespace Opm::Properties {
 
@@ -125,7 +127,7 @@ public:
     {
         using Toolbox = MathToolbox<Evaluation>;
 
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {

--- a/opm/models/io/vtktemperaturemodule.hh
+++ b/opm/models/io/vtktemperaturemodule.hh
@@ -30,6 +30,8 @@
 #include "vtkmultiwriter.hh"
 #include "baseoutputmodule.hh"
 
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/models/utils/propertysystem.hh>
 
@@ -109,7 +111,7 @@ public:
     {
         using Toolbox = MathToolbox<Evaluation>;
 
-        if (!Parameters::get<TypeTag, Properties::EnableVtkOutput>())
+        if (!Parameters::get<TypeTag, Parameters::EnableVtkOutput>())
             return;
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {

--- a/opm/models/parallel/threadmanager.hh
+++ b/opm/models/parallel/threadmanager.hh
@@ -31,7 +31,7 @@
 #include <omp.h>
 #endif
 
-#include <opm/models/discretization/common/fvbaseproperties.hh>
+#include <opm/models/discretization/common/fvbaseparameters.hh>
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/models/utils/propertysystem.hh>
 
@@ -60,7 +60,7 @@ public:
      */
     static void registerParameters()
     {
-        Parameters::registerParam<TypeTag, Properties::ThreadsPerProcess>
+        Parameters::registerParam<TypeTag, Parameters::ThreadsPerProcess>
             ("The maximum number of threads to be instantiated per process "
              "('-1' means 'automatic')");
     }
@@ -78,7 +78,7 @@ public:
     {
         if (queryCommandLineParameter)
         {
-            numThreads_ = Parameters::get<TypeTag, Properties::ThreadsPerProcess>();
+            numThreads_ = Parameters::get<TypeTag, Parameters::ThreadsPerProcess>();
 
             // some safety checks. This is pretty ugly macro-magic, but so what?
 #if !defined(_OPENMP)

--- a/opm/models/ptflash/flashmodel.hh
+++ b/opm/models/ptflash/flashmodel.hh
@@ -127,12 +127,6 @@ struct ExtensiveQuantities<TypeTag, TTag::FlashModel> { using type = Opm::FlashE
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlashModel> { using type = Opm::FlashIndices<TypeTag, /*PVIdx=*/0>; };
 
-// since thermodynamic hints are basically free if the cache for intensive quantities is
-// enabled, and this model usually shows quite a performance improvment if they are
-// enabled, let's enable them by default.
-template<class TypeTag>
-struct EnableThermodynamicHints<TypeTag, TTag::FlashModel> { static constexpr bool value = true; };
-
 // disable molecular diffusion by default
 template<class TypeTag>
 struct EnableDiffusion<TypeTag, TTag::FlashModel> { static constexpr bool value = false; };
@@ -149,6 +143,13 @@ namespace Opm::Parameters {
 // model, so let's try to minimize the number of required ones
 template<class TypeTag>
 struct EnableIntensiveQuantityCache<TypeTag, Properties::TTag::FlashModel>
+{ static constexpr bool value = true; };
+
+// since thermodynamic hints are basically free if the cache for intensive quantities is
+// enabled, and this model usually shows quite a performance improvment if they are
+// enabled, let's enable them by default.
+template<class TypeTag>
+struct EnableThermodynamicHints<TypeTag, Properties::TTag::FlashModel>
 { static constexpr bool value = true; };
 
 } // namespace Opm::Parameters

--- a/opm/models/ptflash/flashmodel.hh
+++ b/opm/models/ptflash/flashmodel.hh
@@ -127,11 +127,6 @@ struct ExtensiveQuantities<TypeTag, TTag::FlashModel> { using type = Opm::FlashE
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlashModel> { using type = Opm::FlashIndices<TypeTag, /*PVIdx=*/0>; };
 
-// The updates of intensive quantities tend to be _very_ expensive for this
-// model, so let's try to minimize the number of required ones
-template<class TypeTag>
-struct EnableIntensiveQuantityCache<TypeTag, TTag::FlashModel> { static constexpr bool value = true; };
-
 // since thermodynamic hints are basically free if the cache for intensive quantities is
 // enabled, and this model usually shows quite a performance improvment if they are
 // enabled, let's enable them by default.
@@ -147,6 +142,16 @@ template<class TypeTag>
 struct EnableEnergy<TypeTag, TTag::FlashModel> { static constexpr bool value = false; };
 
 } // namespace Opm::Properties
+
+namespace Opm::Parameters {
+
+// The updates of intensive quantities tend to be _very_ expensive for this
+// model, so let's try to minimize the number of required ones
+template<class TypeTag>
+struct EnableIntensiveQuantityCache<TypeTag, Properties::TTag::FlashModel>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Parameters
 
 namespace Opm {
 

--- a/opm/models/utils/basicparameters.hh
+++ b/opm/models/utils/basicparameters.hh
@@ -37,6 +37,11 @@ namespace Opm::Parameters {
 template<class TypeTag, class MyTypeTag>
 struct GridGlobalRefinements { using type = Properties::UndefinedProperty; };
 
+//! Property provides the name of the file from which the additional runtime
+//! parameters should to be loaded from
+template<class TypeTag, class MyTypeTag>
+struct ParameterFile { using type = Properties::UndefinedProperty; };
+
 } // namespace Opm:Parameters
 
 #endif

--- a/opm/models/utils/basicparameters.hh
+++ b/opm/models/utils/basicparameters.hh
@@ -1,0 +1,42 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Defines some fundamental parameters for all models.
+ */
+#ifndef EWOMS_BASIC_PARAMETERS_HH
+#define EWOMS_BASIC_PARAMETERS_HH
+
+#include <opm/models/utils/propertysystem.hh>
+
+namespace Opm::Parameters {
+
+//! Property which tells the Vanguard how often the grid should be refined
+//! after creation.
+template<class TypeTag, class MyTypeTag>
+struct GridGlobalRefinements { using type = Properties::UndefinedProperty; };
+
+} // namespace Opm:Parameters
+
+#endif

--- a/opm/models/utils/basicproperties.hh
+++ b/opm/models/utils/basicproperties.hh
@@ -30,14 +30,13 @@
 
 #include <dune/common/parametertree.hh>
 
-#include <opm/models/utils/propertysystem.hh>
+#include <opm/models/utils/basicparameters.hh>
 #include <opm/models/utils/parametersystem.hh>
+#include <opm/models/utils/propertysystem.hh>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/gridpart/adaptiveleafgridpart.hh>
 #endif
-
-#include <string>
 
 namespace Opm::Properties {
 
@@ -99,11 +98,6 @@ struct GridView { using type = UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct GridPart { using type = UndefinedProperty; };
 #endif
-
-//! Property which tells the Vanguard how often the grid should be refined
-//! after creation.
-template<class TypeTag, class MyTypeTag>
-struct GridGlobalRefinements { using type = UndefinedProperty; };
 
 //! Property provides the name of the file from which the additional runtime
 //! parameters should to be loaded from
@@ -233,11 +227,6 @@ struct GridView<TypeTag, TTag::NumericModel> { using type = typename GetPropType
 template<class TypeTag>
 struct ParameterFile<TypeTag, TTag::NumericModel> { static constexpr auto value = ""; };
 
-//! Set the number of refinement levels of the grid to 0. This does not belong
-//! here, strictly speaking.
-template<class TypeTag>
-struct GridGlobalRefinements<TypeTag, TTag::NumericModel> { static constexpr unsigned value = 0; };
-
 //! By default, print the properties on startup
 template<class TypeTag>
 struct PrintProperties<TypeTag, TTag::NumericModel> { static constexpr int value = 2; };
@@ -276,5 +265,15 @@ struct PredeterminedTimeStepsFile<TypeTag, TTag::NumericModel> { static constexp
 
 
 } // namespace Opm::Properties
+
+namespace Opm::Parameters {
+
+//! Set the number of refinement levels of the grid to 0. This does not belong
+//! here, strictly speaking.
+template<class TypeTag>
+struct GridGlobalRefinements<TypeTag, Properties::TTag::NumericModel>
+{ static constexpr unsigned value = 0; };
+
+}
 
 #endif

--- a/opm/models/utils/basicproperties.hh
+++ b/opm/models/utils/basicproperties.hh
@@ -99,11 +99,6 @@ template<class TypeTag, class MyTypeTag>
 struct GridPart { using type = UndefinedProperty; };
 #endif
 
-//! Property provides the name of the file from which the additional runtime
-//! parameters should to be loaded from
-template<class TypeTag, class MyTypeTag>
-struct ParameterFile { using type = UndefinedProperty; };
-
 /*!
  * \brief Print all properties on startup?
  *
@@ -223,10 +218,6 @@ template<class TypeTag>
 struct GridView<TypeTag, TTag::NumericModel> { using type = typename GetPropType<TypeTag, Properties::Grid>::LeafGridView; };
 #endif
 
-//! Set a value for the ParameterFile property
-template<class TypeTag>
-struct ParameterFile<TypeTag, TTag::NumericModel> { static constexpr auto value = ""; };
-
 //! By default, print the properties on startup
 template<class TypeTag>
 struct PrintProperties<TypeTag, TTag::NumericModel> { static constexpr int value = 2; };
@@ -273,6 +264,11 @@ namespace Opm::Parameters {
 template<class TypeTag>
 struct GridGlobalRefinements<TypeTag, Properties::TTag::NumericModel>
 { static constexpr unsigned value = 0; };
+
+//! Set a value for the ParameterFile property
+template<class TypeTag>
+struct ParameterFile<TypeTag, Properties::TTag::NumericModel>
+{ static constexpr auto value = ""; };
 
 }
 

--- a/opm/models/utils/basicproperties.hh
+++ b/opm/models/utils/basicproperties.hh
@@ -38,6 +38,12 @@
 #include <dune/fem/gridpart/adaptiveleafgridpart.hh>
 #endif
 
+namespace Opm {
+
+template<class TypeTag> class DgfVanguard;
+
+}
+
 namespace Opm::Properties {
 
 ///////////////////////////////////
@@ -254,6 +260,8 @@ struct RestartTime<TypeTag, TTag::NumericModel>
 template<class TypeTag>
 struct PredeterminedTimeStepsFile<TypeTag, TTag::NumericModel> { static constexpr auto value = ""; };
 
+template<class TypeTag>
+struct Vanguard<TypeTag, TTag::NumericModel> { using type = Opm::DgfVanguard<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/opm/models/utils/start.hh
+++ b/opm/models/utils/start.hh
@@ -78,7 +78,7 @@ static inline void registerAllParameters_(bool finalizeRegistration = true)
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
     using ThreadManager = GetPropType<TypeTag, Properties::ThreadManager>;
 
-    Parameters::registerParam<TypeTag, Properties::ParameterFile>
+    Parameters::registerParam<TypeTag, Parameters::ParameterFile>
         ("An .ini file which contains a set of run-time parameters");
     Parameters::registerParam<TypeTag, Properties::PrintProperties>
         ("Print the values of the compile time properties at "
@@ -150,7 +150,7 @@ static inline int setupParameters_(int argc,
         return status;
     }
 
-    const std::string paramFileName = Parameters::get<TypeTag, Properties::ParameterFile>(false);
+    const std::string paramFileName = Parameters::get<TypeTag, Parameters::ParameterFile>(false);
     if (!paramFileName.empty()) {
         ////////////////////////////////////////////////////////////
         // add the parameters specified using an .ini file

--- a/tests/co2injection_flash_ecfv.cc
+++ b/tests/co2injection_flash_ecfv.cc
@@ -32,6 +32,7 @@
 #include <opm/material/common/quad.hpp>
 #endif
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/flash/flashmodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/tests/co2injection_flash_ecfv.cc
+++ b/tests/co2injection_flash_ecfv.cc
@@ -42,14 +42,20 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionFlashEcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, FlashModel>; };
+
+struct Co2InjectionFlashEcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, FlashModel>; };
+
 } // end namespace TTag
+
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionFlashEcfvProblem> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionFlashEcfvProblem>
+{ using type = TTag::EcfvDiscretization; };
 
 // use automatic differentiation for this simulator
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionFlashEcfvProblem> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionFlashEcfvProblem>
+{ using type = TTag::AutoDiffLocalLinearizer; };
 
 // use the flash solver adapted to the CO2 injection problem
 template<class TypeTag>
@@ -62,7 +68,8 @@ struct FlashSolver<TypeTag, TTag::Co2InjectionFlashEcfvProblem>
 // else we increase the tolerance of the Newton solver
 #if HAVE_QUAD
 template<class TypeTag>
-struct Scalar<TypeTag, TTag::Co2InjectionFlashEcfvProblem> { using type = quad; };
+struct Scalar<TypeTag, TTag::Co2InjectionFlashEcfvProblem>
+{ using type = quad; };
 #else
 template<class TypeTag>
 struct NewtonTolerance<TypeTag, TTag::Co2InjectionFlashEcfvProblem>

--- a/tests/co2injection_flash_ni_ecfv.cc
+++ b/tests/co2injection_flash_ni_ecfv.cc
@@ -28,7 +28,10 @@
  */
 #include "config.h"
 
+// this must be included before the vanguard
 #include <opm/material/common/quad.hpp>
+
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/flash/flashmodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/tests/co2injection_flash_ni_ecfv.cc
+++ b/tests/co2injection_flash_ni_ecfv.cc
@@ -39,17 +39,23 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionFlashNiEcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, FlashModel>; };
+
+struct Co2InjectionFlashNiEcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, FlashModel>; };
+
 } // end namespace TTag
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem>
+{ using type = TTag::EcfvDiscretization; };
 
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem> { static constexpr bool value = true; };
+struct EnableEnergy<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem>
+{ static constexpr bool value = true; };
 
 //! Use automatic differentiation to linearize the system of PDEs
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem>
+{ using type = TTag::AutoDiffLocalLinearizer; };
 
 // use the CO2 injection problem adapted flash solver
 template<class TypeTag>
@@ -62,7 +68,8 @@ struct FlashSolver<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem>
 // else we increase the tolerance of the Newton solver
 #if HAVE_QUAD
 template<class TypeTag>
-struct Scalar<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem> { using type = quad; };
+struct Scalar<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem>
+{ using type = quad; };
 #else
 template<class TypeTag>
 struct NewtonTolerance<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem>

--- a/tests/co2injection_flash_ni_vcfv.cc
+++ b/tests/co2injection_flash_ni_vcfv.cc
@@ -39,13 +39,19 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionFlashNiVcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, FlashModel>; };
+
+struct Co2InjectionFlashNiVcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, FlashModel>; };
+
 } // end namespace TTag
-template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem> { using type = TTag::VcfvDiscretization; };
 
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem> { static constexpr bool value = true; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
+
+template<class TypeTag>
+struct EnableEnergy<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem>
+{ static constexpr bool value = true; };
 
 // use the CO2 injection problem adapted flash solver
 template<class TypeTag>
@@ -58,7 +64,8 @@ struct FlashSolver<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem>
 // else we increase the tolerance of the Newton solver
 #if HAVE_QUAD
 template<class TypeTag>
-struct Scalar<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem> { using type = quad; };
+struct Scalar<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem>
+{ using type = quad; };
 #else
 template<class TypeTag>
 struct NewtonTolerance<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem>

--- a/tests/co2injection_flash_ni_vcfv.cc
+++ b/tests/co2injection_flash_ni_vcfv.cc
@@ -28,7 +28,10 @@
  */
 #include "config.h"
 
+// this must be included before the vanguard
 #include <opm/material/common/quad.hpp>
+
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/flash/flashmodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>

--- a/tests/co2injection_flash_vcfv.cc
+++ b/tests/co2injection_flash_vcfv.cc
@@ -32,6 +32,7 @@
 #include <opm/material/common/quad.hpp>
 #endif
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/flash/flashmodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>

--- a/tests/co2injection_flash_vcfv.cc
+++ b/tests/co2injection_flash_vcfv.cc
@@ -42,10 +42,14 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionFlashVcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, FlashModel>; };
+
+struct Co2InjectionFlashVcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, FlashModel>; };
+
 } // end namespace TTag
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionFlashVcfvProblem> { using type = TTag::VcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionFlashVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 // use the flash solver adapted to the CO2 injection problem
 template<class TypeTag>
@@ -58,7 +62,8 @@ struct FlashSolver<TypeTag, TTag::Co2InjectionFlashVcfvProblem>
 // else we increase the tolerance of the Newton solver
 #if HAVE_QUAD
 template<class TypeTag>
-struct Scalar<TypeTag, TTag::Co2InjectionFlashVcfvProblem> { using type = quad; };
+struct Scalar<TypeTag, TTag::Co2InjectionFlashVcfvProblem>
+{ using type = quad; };
 #else
 template<class TypeTag>
 struct NewtonTolerance<TypeTag, TTag::Co2InjectionFlashVcfvProblem>

--- a/tests/co2injection_immiscible_ecfv.cc
+++ b/tests/co2injection_immiscible_ecfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/tests/co2injection_immiscible_ni_ecfv.cc
+++ b/tests/co2injection_immiscible_ni_ecfv.cc
@@ -37,7 +37,9 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionImmiscibleNiEcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, ImmiscibleModel>; };
+struct Co2InjectionImmiscibleNiEcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, ImmiscibleModel>; };
+
 } // end namespace TTag
 
 template<class TypeTag>
@@ -45,11 +47,13 @@ struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionImmiscibleNiEcfvPr
 { using type = TTag::EcfvDiscretization; };
 
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::Co2InjectionImmiscibleNiEcfvProblem> { static constexpr bool value = true; };
+struct EnableEnergy<TypeTag, TTag::Co2InjectionImmiscibleNiEcfvProblem>
+{ static constexpr bool value = true; };
 
 //! Use automatic differentiation to linearize the system of PDEs
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionImmiscibleNiEcfvProblem> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionImmiscibleNiEcfvProblem>
+{ using type = TTag::AutoDiffLocalLinearizer; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_immiscible_ni_ecfv.cc
+++ b/tests/co2injection_immiscible_ni_ecfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/tests/co2injection_immiscible_ni_vcfv.cc
+++ b/tests/co2injection_immiscible_ni_vcfv.cc
@@ -43,10 +43,12 @@ struct Co2InjectionImmiscibleNiVcfvProblem
 } // namespace TTag
 
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionImmiscibleNiVcfvProblem> { using type = TTag::VcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionImmiscibleNiVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::Co2InjectionImmiscibleNiVcfvProblem> { static constexpr bool value = true; };
+struct EnableEnergy<TypeTag, TTag::Co2InjectionImmiscibleNiVcfvProblem>
+{ static constexpr bool value = true; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_immiscible_ni_vcfv.cc
+++ b/tests/co2injection_immiscible_ni_vcfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>

--- a/tests/co2injection_immiscible_vcfv.cc
+++ b/tests/co2injection_immiscible_vcfv.cc
@@ -44,7 +44,8 @@ struct Co2InjectionImmiscibleVcfvProblem
 } // namespace TTag
 
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionImmiscibleVcfvProblem> { using type = TTag::VcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionImmiscibleVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_immiscible_vcfv.cc
+++ b/tests/co2injection_immiscible_vcfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>

--- a/tests/co2injection_ncp_ecfv.cc
+++ b/tests/co2injection_ncp_ecfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/ncp/ncpmodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/tests/co2injection_ncp_ecfv.cc
+++ b/tests/co2injection_ncp_ecfv.cc
@@ -37,10 +37,15 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionNcpEcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, NcpModel>; };
+
+struct Co2InjectionNcpEcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, NcpModel>; };
+
 } // end namespace TTag
+
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpEcfvProblem> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpEcfvProblem>
+{ using type = TTag::EcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_ncp_ni_ecfv.cc
+++ b/tests/co2injection_ncp_ni_ecfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/ncp/ncpmodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/tests/co2injection_ncp_ni_ecfv.cc
+++ b/tests/co2injection_ncp_ni_ecfv.cc
@@ -37,16 +37,24 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionNcpNiEcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, NcpModel>; };
+
+struct Co2InjectionNcpNiEcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, NcpModel>; };
+
 } // end namespace TTag
+
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpNiEcfvProblem> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpNiEcfvProblem>
+{ using type = TTag::EcfvDiscretization; };
+
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::Co2InjectionNcpNiEcfvProblem> { static constexpr bool value = true; };
+struct EnableEnergy<TypeTag, TTag::Co2InjectionNcpNiEcfvProblem>
+{ static constexpr bool value = true; };
 
 //! Use automatic differentiation to linearize the system of PDEs
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionNcpNiEcfvProblem> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionNcpNiEcfvProblem>
+{ using type = TTag::AutoDiffLocalLinearizer; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_ncp_ni_vcfv.cc
+++ b/tests/co2injection_ncp_ni_vcfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/ncp/ncpmodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>

--- a/tests/co2injection_ncp_ni_vcfv.cc
+++ b/tests/co2injection_ncp_ni_vcfv.cc
@@ -37,12 +37,18 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionNcpNiVcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, NcpModel>; };
+
+struct Co2InjectionNcpNiVcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, NcpModel>; };
+
 } // end namespace TTag
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpNiVcfvProblem> { using type = TTag::VcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpNiVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
+
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::Co2InjectionNcpNiVcfvProblem> { static constexpr bool value = true; };
+struct EnableEnergy<TypeTag, TTag::Co2InjectionNcpNiVcfvProblem>
+{ static constexpr bool value = true; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_ncp_vcfv.cc
+++ b/tests/co2injection_ncp_vcfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/ncp/ncpmodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>

--- a/tests/co2injection_ncp_vcfv.cc
+++ b/tests/co2injection_ncp_vcfv.cc
@@ -38,10 +38,15 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionNcpVcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, NcpModel>; };
+
+struct Co2InjectionNcpVcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, NcpModel>; };
+
 } // end namespace TTag
+
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpVcfvProblem> { using type = TTag::VcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_pvs_ecfv.cc
+++ b/tests/co2injection_pvs_ecfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/tests/co2injection_pvs_ecfv.cc
+++ b/tests/co2injection_pvs_ecfv.cc
@@ -37,10 +37,15 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionPvsEcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, PvsModel>; };
+
+struct Co2InjectionPvsEcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, PvsModel>; };
+
 } // end namespace TTag
+
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsEcfvProblem> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsEcfvProblem>
+{ using type = TTag::EcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_pvs_ni_ecfv.cc
+++ b/tests/co2injection_pvs_ni_ecfv.cc
@@ -37,17 +37,23 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionPvsNiEcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, PvsModel>; };
+
+struct Co2InjectionPvsNiEcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, PvsModel>; };
+
 } // end namespace TTag
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsNiEcfvProblem> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsNiEcfvProblem>
+{ using type = TTag::EcfvDiscretization; };
 
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::Co2InjectionPvsNiEcfvProblem> { static constexpr bool value = true; };
+struct EnableEnergy<TypeTag, TTag::Co2InjectionPvsNiEcfvProblem>
+{ static constexpr bool value = true; };
 
 //! Use automatic differentiation to linearize the system of PDEs
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionPvsNiEcfvProblem> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionPvsNiEcfvProblem>
+{ using type = TTag::AutoDiffLocalLinearizer; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_pvs_ni_ecfv.cc
+++ b/tests/co2injection_pvs_ni_ecfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/tests/co2injection_pvs_ni_vcfv.cc
+++ b/tests/co2injection_pvs_ni_vcfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>

--- a/tests/co2injection_pvs_ni_vcfv.cc
+++ b/tests/co2injection_pvs_ni_vcfv.cc
@@ -37,13 +37,19 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionPvsNiVcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, PvsModel>; };
+
+struct Co2InjectionPvsNiVcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, PvsModel>; };
+
 } // end namespace TTag
-template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsNiVcfvProblem> { using type = TTag::VcfvDiscretization; };
 
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::Co2InjectionPvsNiVcfvProblem> { static constexpr bool value = true; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsNiVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
+
+template<class TypeTag>
+struct EnableEnergy<TypeTag, TTag::Co2InjectionPvsNiVcfvProblem>
+{ static constexpr bool value = true; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_pvs_vcfv.cc
+++ b/tests/co2injection_pvs_vcfv.cc
@@ -38,10 +38,15 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct Co2InjectionPvsVcfvProblem { using InheritsFrom = std::tuple<Co2InjectionBaseProblem, PvsModel>; };
+
+struct Co2InjectionPvsVcfvProblem
+{ using InheritsFrom = std::tuple<Co2InjectionBaseProblem, PvsModel>; };
+
 } // end namespace TTag
+
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsVcfvProblem> { using type = TTag::VcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/tests/co2injection_pvs_vcfv.cc
+++ b/tests/co2injection_pvs_vcfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>

--- a/tests/cuvette_pvs.cc
+++ b/tests/cuvette_pvs.cc
@@ -37,7 +37,9 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct CuvetteProblem { using InheritsFrom = std::tuple<CuvetteBaseProblem, PvsModel>; };
+struct CuvetteProblem
+{ using InheritsFrom = std::tuple<CuvetteBaseProblem, PvsModel>; };
+
 } // end namespace TTag
 
 } // namespace Opm::Properties

--- a/tests/cuvette_pvs.cc
+++ b/tests/cuvette_pvs.cc
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>

--- a/tests/groundwater_immiscible.cc
+++ b/tests/groundwater_immiscible.cc
@@ -35,7 +35,10 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct GroundWaterProblem { using InheritsFrom = std::tuple<GroundWaterBaseProblem, ImmiscibleSinglePhaseModel>; };
+
+struct GroundWaterProblem
+{ using InheritsFrom = std::tuple<GroundWaterBaseProblem, ImmiscibleSinglePhaseModel>; };
+
 } // end namespace TTag
 
 } // namespace Opm::Properties

--- a/tests/groundwater_immiscible.cc
+++ b/tests/groundwater_immiscible.cc
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include "problems/groundwaterproblem.hh"

--- a/tests/infiltration_pvs.cc
+++ b/tests/infiltration_pvs.cc
@@ -36,7 +36,8 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct InfiltrationProblem { using InheritsFrom = std::tuple<InfiltrationBaseProblem, PvsModel>; };
+struct InfiltrationProblem
+{ using InheritsFrom = std::tuple<InfiltrationBaseProblem, PvsModel>; };
 } // end namespace TTag
 
 } // namespace Opm::Properties

--- a/tests/infiltration_pvs.cc
+++ b/tests/infiltration_pvs.cc
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>

--- a/tests/lens_richards_ecfv.cc
+++ b/tests/lens_richards_ecfv.cc
@@ -37,14 +37,19 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct RichardsLensEcfvProblem { using InheritsFrom = std::tuple<RichardsLensProblem>; };
+struct RichardsLensEcfvProblem
+{ using InheritsFrom = std::tuple<RichardsLensProblem>; };
+
 } // end namespace TTag
+
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::RichardsLensEcfvProblem> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::RichardsLensEcfvProblem>
+{ using type = TTag::EcfvDiscretization; };
 
 //! Use automatic differentiation to linearize the system of PDEs
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::RichardsLensEcfvProblem> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::RichardsLensEcfvProblem>
+{ using type = TTag::AutoDiffLocalLinearizer; };
 
 } // namespace Opm::Properties
 

--- a/tests/lens_richards_ecfv.cc
+++ b/tests/lens_richards_ecfv.cc
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>

--- a/tests/lens_richards_vcfv.cc
+++ b/tests/lens_richards_vcfv.cc
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>

--- a/tests/lens_richards_vcfv.cc
+++ b/tests/lens_richards_vcfv.cc
@@ -37,10 +37,15 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct RichardsLensVcfvProblem { using InheritsFrom = std::tuple<RichardsLensProblem>; };
+
+struct RichardsLensVcfvProblem
+{ using InheritsFrom = std::tuple<RichardsLensProblem>; };
+
 } // end namespace TTag
+
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::RichardsLensVcfvProblem> { using type = TTag::VcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::RichardsLensVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/tests/obstacle_immiscible.cc
+++ b/tests/obstacle_immiscible.cc
@@ -37,7 +37,9 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct ObstacleProblem { using InheritsFrom = std::tuple<ObstacleBaseProblem, ImmiscibleModel>; };
+struct ObstacleProblem
+{ using InheritsFrom = std::tuple<ObstacleBaseProblem, ImmiscibleModel>; };
+
 } // end namespace TTag
 
 } // namespace Opm::Properties

--- a/tests/obstacle_immiscible.cc
+++ b/tests/obstacle_immiscible.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>

--- a/tests/obstacle_ncp.cc
+++ b/tests/obstacle_ncp.cc
@@ -37,7 +37,10 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct ObstacleProblem { using InheritsFrom = std::tuple<ObstacleBaseProblem, NcpModel>; };
+
+struct ObstacleProblem
+{ using InheritsFrom = std::tuple<ObstacleBaseProblem, NcpModel>; };
+
 } // end namespace TTag
 
 } // namespace Opm::Properties

--- a/tests/obstacle_ncp.cc
+++ b/tests/obstacle_ncp.cc
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/ncp/ncpmodel.hh>
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>

--- a/tests/obstacle_pvs.cc
+++ b/tests/obstacle_pvs.cc
@@ -29,6 +29,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>

--- a/tests/obstacle_pvs.cc
+++ b/tests/obstacle_pvs.cc
@@ -39,12 +39,16 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct ObstacleProblem { using InheritsFrom = std::tuple<ObstacleBaseProblem, PvsModel>; };
+
+struct ObstacleProblem
+{ using InheritsFrom = std::tuple<ObstacleBaseProblem, PvsModel>; };
+
 } // end namespace TTag
 
 // Verbosity of the PVS model (0=silent, 1=medium, 2=chatty)
 template<class TypeTag>
-struct PvsVerbosity<TypeTag, TTag::ObstacleProblem> { static constexpr int value = 1; };
+struct PvsVerbosity<TypeTag, TTag::ObstacleProblem>
+{ static constexpr int value = 1; };
 
 } // namespace Opm::Properties
 

--- a/tests/outflow_pvs.cc
+++ b/tests/outflow_pvs.cc
@@ -37,12 +37,16 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct OutflowProblem { using InheritsFrom = std::tuple<OutflowBaseProblem, PvsModel>; };
+
+struct OutflowProblem
+{ using InheritsFrom = std::tuple<OutflowBaseProblem, PvsModel>; };
+
 } // end namespace TTag
 
 // Verbosity of the PVS model (0=silent, 1=medium, 2=chatty)
 template<class TypeTag>
-struct PvsVerbosity<TypeTag, TTag::OutflowProblem> { static constexpr int value = 1; };
+struct PvsVerbosity<TypeTag, TTag::OutflowProblem>
+{ static constexpr int value = 1; };
 
 } // namespace Opm::Properties
 

--- a/tests/outflow_pvs.cc
+++ b/tests/outflow_pvs.cc
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>

--- a/tests/problems/cuvetteproblem.hh
+++ b/tests/problems/cuvetteproblem.hh
@@ -80,14 +80,6 @@ struct FluidSystem<TypeTag, TTag::CuvetteBaseProblem>
 template<class TypeTag>
 struct EnableGravity<TypeTag, TTag::CuvetteBaseProblem> { static constexpr bool value = true; };
 
-// Set the maximum time step
-template<class TypeTag>
-struct MaxTimeStepSize<TypeTag, TTag::CuvetteBaseProblem>
-{
-    using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 600.;
-};
-
 // Set the material Law
 template<class TypeTag>
 struct MaterialLaw<TypeTag, TTag::CuvetteBaseProblem>
@@ -145,6 +137,18 @@ template<class TypeTag>
 struct GridFile<TypeTag, TTag::CuvetteBaseProblem> { static constexpr auto value = "./data/cuvette_11x4.dgf"; };
 
 } // namespace Opm::Properties
+
+namespace Opm::Parameters {
+
+// Set the maximum time step
+template<class TypeTag>
+struct MaxTimeStepSize<TypeTag, Properties::TTag::CuvetteBaseProblem>
+{
+    using type = GetPropType<TypeTag, Properties::Scalar>;
+    static constexpr type value = 600.;
+};
+
+} // namespace Opm::Parameters
 
 namespace Opm {
 /*!

--- a/tests/problems/lensproblem.hh
+++ b/tests/problems/lensproblem.hh
@@ -225,10 +225,6 @@ struct InitialTimeStepSize<TypeTag, TTag::LensBaseProblem>
 template<class TypeTag>
 struct VtkWriteIntrinsicPermeabilities<TypeTag, TTag::LensBaseProblem> { static constexpr bool value = true; };
 
-// enable the storage cache by default for this problem
-template<class TypeTag>
-struct EnableStorageCache<TypeTag, TTag::LensBaseProblem> { static constexpr bool value = true; };
-
 } // namespace Opm::Properties
 
 namespace Opm::Parameters {
@@ -236,6 +232,11 @@ namespace Opm::Parameters {
 // enable the cache for intensive quantities by default for this problem
 template<class TypeTag>
 struct EnableIntensiveQuantityCache<TypeTag, Properties::TTag::LensBaseProblem>
+{ static constexpr bool value = true; };
+
+// enable the storage cache by default for this problem
+template<class TypeTag>
+struct EnableStorageCache<TypeTag, Properties::TTag::LensBaseProblem>
 { static constexpr bool value = true; };
 
 } // namespace Opm::Parameters

--- a/tests/problems/lensproblem.hh
+++ b/tests/problems/lensproblem.hh
@@ -229,11 +229,16 @@ struct VtkWriteIntrinsicPermeabilities<TypeTag, TTag::LensBaseProblem> { static 
 template<class TypeTag>
 struct EnableStorageCache<TypeTag, TTag::LensBaseProblem> { static constexpr bool value = true; };
 
+} // namespace Opm::Properties
+
+namespace Opm::Parameters {
+
 // enable the cache for intensive quantities by default for this problem
 template<class TypeTag>
-struct EnableIntensiveQuantityCache<TypeTag, TTag::LensBaseProblem> { static constexpr bool value = true; };
+struct EnableIntensiveQuantityCache<TypeTag, Properties::TTag::LensBaseProblem>
+{ static constexpr bool value = true; };
 
-} // namespace Opm::Properties
+} // namespace Opm::Parameters
 
 namespace Opm {
 

--- a/tests/reservoir_blackoil_ecfv.cc
+++ b/tests/reservoir_blackoil_ecfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/blackoil/blackoilmodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/tests/reservoir_blackoil_ecfv.cc
+++ b/tests/reservoir_blackoil_ecfv.cc
@@ -39,16 +39,21 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct ReservoirBlackOilEcfvProblem { using InheritsFrom = std::tuple<ReservoirBaseProblem, BlackOilModel>; };
+
+struct ReservoirBlackOilEcfvProblem
+{ using InheritsFrom = std::tuple<ReservoirBaseProblem, BlackOilModel>; };
+
 } // end namespace TTag
 
 // Select the element centered finite volume method as spatial discretization
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirBlackOilEcfvProblem> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirBlackOilEcfvProblem>
+{ using type = TTag::EcfvDiscretization; };
 
 // Use automatic differentiation to linearize the system of PDEs
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::ReservoirBlackOilEcfvProblem> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::ReservoirBlackOilEcfvProblem>
+{ using type = TTag::AutoDiffLocalLinearizer; };
 
 } // namespace Opm::Properties
 

--- a/tests/reservoir_blackoil_vcfv.cc
+++ b/tests/reservoir_blackoil_vcfv.cc
@@ -38,12 +38,16 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct ReservoirBlackOilVcfvProblem { using InheritsFrom = std::tuple<ReservoirBaseProblem, BlackOilModel>; };
+
+struct ReservoirBlackOilVcfvProblem
+{ using InheritsFrom = std::tuple<ReservoirBaseProblem, BlackOilModel>; };
+
 } // end namespace TTag
 
 // Select the vertex centered finite volume method as spatial discretization
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirBlackOilVcfvProblem> { using type = TTag::VcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirBlackOilVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/tests/reservoir_blackoil_vcfv.cc
+++ b/tests/reservoir_blackoil_vcfv.cc
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/blackoil/blackoilmodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>

--- a/tests/reservoir_ncp_ecfv.cc
+++ b/tests/reservoir_ncp_ecfv.cc
@@ -38,16 +38,21 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct ReservoirNcpEcfvProblem { using InheritsFrom = std::tuple<ReservoirBaseProblem, NcpModel>; };
+
+struct ReservoirNcpEcfvProblem
+{ using InheritsFrom = std::tuple<ReservoirBaseProblem, NcpModel>; };
+
 } // end namespace TTag
 
 // Select the element centered finite volume method as spatial discretization
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirNcpEcfvProblem> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirNcpEcfvProblem>
+{ using type = TTag::EcfvDiscretization; };
 
 //! use automatic differentiation to linearize the system of PDEs
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::ReservoirNcpEcfvProblem> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::ReservoirNcpEcfvProblem>
+{ using type = TTag::AutoDiffLocalLinearizer; };
 
 } // namespace Opm::Properties
 

--- a/tests/reservoir_ncp_ecfv.cc
+++ b/tests/reservoir_ncp_ecfv.cc
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/ncp/ncpmodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/tests/reservoir_ncp_vcfv.cc
+++ b/tests/reservoir_ncp_vcfv.cc
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/ncp/ncpmodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>

--- a/tests/reservoir_ncp_vcfv.cc
+++ b/tests/reservoir_ncp_vcfv.cc
@@ -46,11 +46,6 @@ struct ReservoirNcpVcfvProblem { using InheritsFrom = std::tuple<ReservoirBasePr
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirNcpVcfvProblem> { using type = TTag::VcfvDiscretization; };
 
-// enable the storage cache for this problem so that the storage cache receives wider
-// testing
-template<class TypeTag>
-struct EnableStorageCache<TypeTag, TTag::ReservoirNcpVcfvProblem> { static constexpr bool value = true; };
-
 // reduce the base epsilon for the finite difference method to 10^-11. for some reason
 // the simulator converges better with this. (TODO: use automatic differentiation?)
 template<class TypeTag>
@@ -60,8 +55,17 @@ struct BaseEpsilon<TypeTag, TTag::ReservoirNcpVcfvProblem>
     static constexpr type value = 1e-11;
 };
 
-
 } // namespace Opm::Properties
+
+namespace Opm::Parameters {
+
+// enable the storage cache for this problem so that the storage cache receives wider
+// testing
+template<class TypeTag>
+struct EnableStorageCache<TypeTag, Properties::TTag::ReservoirNcpVcfvProblem>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Parameters
 
 int main(int argc, char **argv)
 {

--- a/tests/reservoir_ncp_vcfv.cc
+++ b/tests/reservoir_ncp_vcfv.cc
@@ -39,12 +39,16 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct ReservoirNcpVcfvProblem { using InheritsFrom = std::tuple<ReservoirBaseProblem, NcpModel>; };
+
+struct ReservoirNcpVcfvProblem
+{ using InheritsFrom = std::tuple<ReservoirBaseProblem, NcpModel>; };
+
 } // end namespace TTag
 
 // Select the vertex centered finite volume method as spatial discretization
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirNcpVcfvProblem> { using type = TTag::VcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirNcpVcfvProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 // reduce the base epsilon for the finite difference method to 10^-11. for some reason
 // the simulator converges better with this. (TODO: use automatic differentiation?)

--- a/tests/waterair_pvs_ni.cc
+++ b/tests/waterair_pvs_ni.cc
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
 #include "problems/waterairproblem.hh"

--- a/tests/waterair_pvs_ni.cc
+++ b/tests/waterair_pvs_ni.cc
@@ -35,11 +35,13 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct WaterAirProblem { using InheritsFrom = std::tuple<WaterAirBaseProblem, PvsModel>; };
+struct WaterAirProblem
+{ using InheritsFrom = std::tuple<WaterAirBaseProblem, PvsModel>; };
 } // end namespace TTag
 
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::WaterAirProblem> { static constexpr bool value = true; };
+struct EnableEnergy<TypeTag, TTag::WaterAirProblem>
+{ static constexpr bool value = true; };
 
 } // namespace Opm::Properties
 


### PR DESCRIPTION
Currently both of these use the Opm::Properties namespace. This causes confusion, and while they (currently) look somewhat similar on the surface the intended usage for these two beasts are quite different.
To make things cleaner, more separate, and easier to change later on, I think we should move parameters to the Opm::Parameters namespace. This starts this journey by introducing this split for the FvBaseDiscretization properties.