### PR TITLE
initialize water saturation for gas dissolved in water

### DIFF
--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -584,6 +584,8 @@ public:
             sw = (*this)[waterSwitchIdx];
         if (primaryVarsMeaningGas() == GasMeaning::Sg)
             sg = (*this)[compositionSwitchIdx];
+        if (primaryVarsMeaningWater() == WaterMeaning::Rsw)
+            sw = 1.0;
 
         if (primaryVarsMeaningGas() == GasMeaning::Disabled && gasEnabled)
             sg = 1.0 - sw; // water + gas case


### PR DESCRIPTION
For the case of gas being dissolved in water, the water saturation is not initialized explicitly, such that it is currently set to the default 0.0.

This fix should not change the behaviour of `primaryVarsMeaningWater` as the water saturation is hardcoded for the RSW case in [line 768](https://github.com/OPM/opm-models/blob/81cddce56fa5630a696272f90b5ad8a240e05968/opm/models/blackoil/blackoilprimaryvariables.hh#L768)
```C++
computeCapillaryPressures_(pC, /*so=*/ 0.0,  /*sg=*/ 0.0, /*sw=*/ 1.0, matParams);
```
but it might cause issues later if someone uses sw directly. 

For  `primaryVarsMeaningGas` there might be an impact, depending on what primary variable is being used for gas.

There might be other bugs like this in the code, as it is hard to have an overview of all the different combinations of the different primary variable states.