### PR TITLE
Feature/add failure flag to tasklets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,8 @@ opm_add_test(tutorial1
 
 opm_add_test(test_tasklets
              DRIVER_ARGS --plain)
+opm_add_test(test_tasklets_failure
+             DRIVER_ARGS --plain)
 
 opm_add_test(test_mpiutil
              PROCESSORS 4

--- a/opm/models/parallel/tasklets.hh
+++ b/opm/models/parallel/tasklets.hh
@@ -199,6 +199,11 @@ public:
         }
     }
 
+    bool failure() const
+    {
+        return this->failureFlag_.load(std::memory_order_relaxed);
+    }
+
     /*!
      * \brief Returns the index of the current worker thread.
      *
@@ -224,11 +229,6 @@ public:
      */
     void dispatch(std::shared_ptr<TaskletInterface> tasklet)
     {
-        if (failureFlag_.load(std::memory_order_relaxed)) {
-            std::cerr << "Failure flag of the TaskletRunner is set. Not dispatching new tasklets.\n";
-            exit(EXIT_FAILURE);
-        }
-
         if (threads_.empty()) {
             // run the tasklet immediately in synchronous mode.
             while (tasklet->referenceCount() > 0) {
@@ -313,11 +313,6 @@ protected:
     void run_()
     {
         while (true) {
-            // Check if failure flag is set
-            if (failureFlag_.load(std::memory_order_relaxed)) {
-                std::cerr << "Failure flag of the TaskletRunner is set. Exiting thread.\n";
-                exit(EXIT_FAILURE);
-            }
 
             // wait until tasklets have been pushed to the queue. first we need to lock
             // mutex for access to taskletQueue_

--- a/tests/test_tasklets.cc
+++ b/tests/test_tasklets.cc
@@ -35,7 +35,8 @@
 
 std::mutex outputMutex;
 
-Opm::TaskletRunner *runner;
+// The runner is created on the heap for the assertion and outputs in the run function of the tasklets.
+std::unique_ptr<Opm::TaskletRunner> runner{};
 
 class SleepTasklet : public Opm::TaskletInterface
 {
@@ -75,7 +76,7 @@ int SleepTasklet::numInstantiated_ = 0;
 int main()
 {
     int numWorkers = 2;
-    runner = new Opm::TaskletRunner(numWorkers);
+    runner = std::make_unique<Opm::TaskletRunner>(numWorkers);
 
     // the master thread is not a worker thread
     assert(runner->workerThreadIndex() < 0);
@@ -93,8 +94,6 @@ int main()
 
     runner->dispatchFunction(sleepAndPrintFunction);
     runner->dispatchFunction(sleepAndPrintFunction, /*numInvokations=*/6);
-
-    delete runner;
 
     return 0;
 }

--- a/tests/test_tasklets.cc
+++ b/tests/test_tasklets.cc
@@ -51,9 +51,8 @@ public:
     {
         assert(0 <= runner->workerThreadIndex() && runner->workerThreadIndex() < runner->numWorkerThreads());
         std::this_thread::sleep_for(std::chrono::milliseconds(mseconds_));
-        outputMutex.lock();
+        std::lock_guard<std::mutex> guard(outputMutex);
         std::cout << "Sleep tasklet " << n_ << " of " << mseconds_ << " ms completed by worker thread " << runner->workerThreadIndex() << std::endl;
-        outputMutex.unlock();
     }
 
 private:
@@ -67,9 +66,8 @@ void sleepAndPrintFunction()
 {
     int ms = 100;
     std::this_thread::sleep_for(std::chrono::milliseconds(ms));
-    outputMutex.lock();
+    std::lock_guard<std::mutex> guard(outputMutex);
     std::cout << "Sleep completed by worker thread " << runner->workerThreadIndex() << std::endl;
-    outputMutex.unlock();
 }
 
 int SleepTasklet::numInstantiated_ = 0;

--- a/tests/test_tasklets_failure.cc
+++ b/tests/test_tasklets_failure.cc
@@ -91,8 +91,8 @@ void execute () {
     runner = std::make_unique<Opm::TaskletRunner>(numWorkers);
 
     // the master thread is not a worker thread
-    assert(runner->workerThreadIndex() < 0);
-    assert(runner->numWorkerThreads() == numWorkers);
+    BOOST_REQUIRE_LT(runner->workerThreadIndex(), 0);
+    BOOST_REQUIRE_EQUAL(runner->numWorkerThreads(), numWorkers);
 
     // Dispatch some successful tasklets
     for (int i = 0; i < 5; ++i) {

--- a/tests/test_tasklets_failure.cc
+++ b/tests/test_tasklets_failure.cc
@@ -1,0 +1,135 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief This file serves as an example of how to use the tasklet mechanism for
+ *        asynchronous work, especially for tasklets that fail.
+ */
+#define BOOST_TEST_MODULE TASKLETS_FAILURE
+
+//#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
+#include <chrono>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <cassert>
+
+#include "config.h"
+#include <opm/models/parallel/tasklets.hh>
+
+std::mutex outputMutex;
+
+Opm::TaskletRunner *runner;
+
+class SleepTasklet : public Opm::TaskletInterface
+{
+public:
+    SleepTasklet(int mseconds, int id)
+        : mseconds_(mseconds),
+          id_(id)
+    {}
+
+    void run() override
+    {
+        assert(0 <= runner->workerThreadIndex() && runner->workerThreadIndex() < runner->numWorkerThreads());
+        std::cout << "Sleep tasklet " << id_ << " of " << mseconds_ << " ms starting sleep on worker thread " << runner->workerThreadIndex() << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(mseconds_));
+        outputMutex.lock();
+        std::cout << "Sleep tasklet " << id_ << " of " << mseconds_ << " ms completed by worker thread " << runner->workerThreadIndex() << std::endl;
+        outputMutex.unlock();
+    }
+
+private:
+    int mseconds_;
+    int id_;
+};
+
+class FailingSleepTasklet : public Opm::TaskletInterface
+{
+public:
+    FailingSleepTasklet(int mseconds)
+        : mseconds_(mseconds)
+    {}
+    void run() override
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(mseconds_));
+        outputMutex.lock();
+        std::cout << "Failing sleep tasklet of " << mseconds_ << " ms failing now, on work thread " << runner->workerThreadIndex() << std::endl;
+        outputMutex.unlock();
+        throw std::logic_error("Intentional failure for testing");
+    }
+
+private:
+    int mseconds_;
+};
+
+void execute () {
+        int numWorkers = 2;
+        runner = new Opm::TaskletRunner(numWorkers);
+
+        // the master thread is not a worker thread
+        assert(runner->workerThreadIndex() < 0);
+        assert(runner->numWorkerThreads() == numWorkers);
+
+        // Dispatch some successful tasklets
+        for (int i = 0; i < 5; ++i) {
+            auto st = std::make_shared<SleepTasklet>(10,i);
+            runner->dispatch(st);
+        }
+
+        // Dispatch a failing tasklet
+        auto failingSleepTasklet = std::make_shared<FailingSleepTasklet>(100);
+        runner->dispatch(failingSleepTasklet);
+
+        // Dispatch more successful tasklets
+        for (int i = 5; i < 10; ++i) {
+            auto st = std::make_shared<SleepTasklet>(10,i);
+            runner->dispatch(st);
+        }
+
+        std::cout << "before barrier" << std::endl;
+        runner->barrier();
+    }
+BOOST_AUTO_TEST_SUITE(Tasklets)
+BOOST_AUTO_TEST_CASE(TASKLETS_FAILURE) {
+    pid_t pid = fork(); // Create a new process, such that this child process can call exit(EXIT_FAILURE)
+    if (pid == -1) {
+        BOOST_FAIL("Fork failed");
+    } else if (pid == 0) {
+        // Child process
+        execute();
+        _exit(0);  // Should never reach here
+    } else {
+        // Parent process
+        std::cout << "Checking failure of child process with parent process, process id " << pid << std::endl;
+        int status;
+        waitpid(pid, &status, 0);
+        BOOST_CHECK(WIFEXITED(status));  // Check if the child process exited
+        BOOST_CHECK_EQUAL(WEXITSTATUS(status), EXIT_FAILURE);  // Check if the exit status is EXIT_FAILURE
+    }
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_tasklets_failure.cc
+++ b/tests/test_tasklets_failure.cc
@@ -87,46 +87,46 @@ private:
 };
 
 void execute () {
-        int numWorkers = 2;
-        runner = std::make_unique<Opm::TaskletRunner>(numWorkers);
+    int numWorkers = 2;
+    runner = std::make_unique<Opm::TaskletRunner>(numWorkers);
 
-        // the master thread is not a worker thread
-        assert(runner->workerThreadIndex() < 0);
-        assert(runner->numWorkerThreads() == numWorkers);
+    // the master thread is not a worker thread
+    assert(runner->workerThreadIndex() < 0);
+    assert(runner->numWorkerThreads() == numWorkers);
 
-        // Dispatch some successful tasklets
-        for (int i = 0; i < 5; ++i) {
-            runner->barrier();
-
-            if (runner->failure()) {
-                exit(EXIT_FAILURE);
-            }
-            auto st = std::make_shared<SleepTasklet>(10,i);
-            runner->dispatch(st);
-        }
-
+    // Dispatch some successful tasklets
+    for (int i = 0; i < 5; ++i) {
         runner->barrier();
+
         if (runner->failure()) {
             exit(EXIT_FAILURE);
         }
-        // Dispatch a failing tasklet
-        auto failingSleepTasklet = std::make_shared<FailingSleepTasklet>(100);
-        runner->dispatch(failingSleepTasklet);
-
-        // Dispatch more successful tasklets
-        for (int i = 5; i < 10; ++i) {
-            runner->barrier();
-
-            if (runner->failure()) {
-                exit(EXIT_FAILURE);
-            }
-            auto st = std::make_shared<SleepTasklet>(10,i);
-            runner->dispatch(st);
-        }
-
-        std::cout << "before barrier" << std::endl;
-        runner->barrier();
+        auto st = std::make_shared<SleepTasklet>(10,i);
+        runner->dispatch(st);
     }
+
+    runner->barrier();
+    if (runner->failure()) {
+        exit(EXIT_FAILURE);
+    }
+    // Dispatch a failing tasklet
+    auto failingSleepTasklet = std::make_shared<FailingSleepTasklet>(100);
+    runner->dispatch(failingSleepTasklet);
+
+    // Dispatch more successful tasklets
+    for (int i = 5; i < 10; ++i) {
+        runner->barrier();
+
+        if (runner->failure()) {
+            exit(EXIT_FAILURE);
+        }
+        auto st = std::make_shared<SleepTasklet>(10,i);
+        runner->dispatch(st);
+    }
+
+    std::cout << "before barrier" << std::endl;
+    runner->barrier();
+}
 BOOST_AUTO_TEST_SUITE(Tasklets)
 BOOST_AUTO_TEST_CASE(TASKLETS_FAILURE) {
     pid_t pid = fork(); // Create a new process, such that this child process can call exit(EXIT_FAILURE)

--- a/tests/test_tasklets_failure.cc
+++ b/tests/test_tasklets_failure.cc
@@ -58,9 +58,8 @@ public:
         assert(0 <= runner->workerThreadIndex() && runner->workerThreadIndex() < runner->numWorkerThreads());
         std::cout << "Sleep tasklet " << id_ << " of " << mseconds_ << " ms starting sleep on worker thread " << runner->workerThreadIndex() << std::endl;
         std::this_thread::sleep_for(std::chrono::milliseconds(mseconds_));
-        outputMutex.lock();
+        std::lock_guard<std::mutex> guard(outputMutex);
         std::cout << "Sleep tasklet " << id_ << " of " << mseconds_ << " ms completed by worker thread " << runner->workerThreadIndex() << std::endl;
-        outputMutex.unlock();
     }
 
 private:
@@ -77,9 +76,8 @@ public:
     void run() override
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(mseconds_));
-        outputMutex.lock();
+        std::lock_guard<std::mutex> guard(outputMutex);
         std::cout << "Failing sleep tasklet of " << mseconds_ << " ms failing now, on work thread " << runner->workerThreadIndex() << std::endl;
-        outputMutex.unlock();
         throw std::logic_error("Intentional failure for testing");
     }
 

--- a/tests/test_tasklets_failure.cc
+++ b/tests/test_tasklets_failure.cc
@@ -97,16 +97,30 @@ void execute () {
 
         // Dispatch some successful tasklets
         for (int i = 0; i < 5; ++i) {
+            runner->barrier();
+
+            if (runner->failure()) {
+                exit(EXIT_FAILURE);
+            }
             auto st = std::make_shared<SleepTasklet>(10,i);
             runner->dispatch(st);
         }
 
+        runner->barrier();
+        if (runner->failure()) {
+            exit(EXIT_FAILURE);
+        }
         // Dispatch a failing tasklet
         auto failingSleepTasklet = std::make_shared<FailingSleepTasklet>(100);
         runner->dispatch(failingSleepTasklet);
 
         // Dispatch more successful tasklets
         for (int i = 5; i < 10; ++i) {
+            runner->barrier();
+
+            if (runner->failure()) {
+                exit(EXIT_FAILURE);
+            }
             auto st = std::make_shared<SleepTasklet>(10,i);
             runner->dispatch(st);
         }

--- a/tests/test_tasklets_failure.cc
+++ b/tests/test_tasklets_failure.cc
@@ -43,7 +43,8 @@
 
 std::mutex outputMutex;
 
-Opm::TaskletRunner *runner;
+// The runner is created on the heap for the assertion and outputs in the run function of the tasklets.
+std::unique_ptr<Opm::TaskletRunner> runner{};
 
 class SleepTasklet : public Opm::TaskletInterface
 {
@@ -87,7 +88,7 @@ private:
 
 void execute () {
         int numWorkers = 2;
-        runner = new Opm::TaskletRunner(numWorkers);
+        runner = std::make_unique<Opm::TaskletRunner>(numWorkers);
 
         // the master thread is not a worker thread
         assert(runner->workerThreadIndex() < 0);


### PR DESCRIPTION
As suggested by https://github.com/OPM/opm-common/pull/3870#issuecomment-1911661089, adding a failureFlag to the TaskletRunner, will solve https://github.com/OPM/opm-models/issues/871