### PR TITLE
changed: remove the print-properties parameter

### DIFF
--- a/opm/models/utils/basicparameters.hh
+++ b/opm/models/utils/basicparameters.hh
@@ -87,15 +87,6 @@ struct PredeterminedTimeStepsFile { using type = Properties::UndefinedProperty; 
 template<class TypeTag, class MyTypeTag>
 struct PrintParameters { using type = Properties::UndefinedProperty; };
 
-/*!
- * \brief Print all properties on startup?
- *
- * 0 means 'no', 1 means 'yes', 2 means 'print only to logfiles'. The
- * default is 2.
- */
-template<class TypeTag, class MyTypeTag>
-struct PrintProperties { using type = Properties::UndefinedProperty; };
-
 //! The default value for the simulation's restart time
 template<class TypeTag, class MyTypeTag>
 struct RestartTime { using type = Properties::UndefinedProperty; };

--- a/opm/models/utils/basicproperties.hh
+++ b/opm/models/utils/basicproperties.hh
@@ -219,11 +219,6 @@ template<class TypeTag>
 struct PrintParameters<TypeTag, Properties::TTag::NumericModel>
 { static constexpr int value = 2; };
 
-//! By default, print the properties on startup
-template<class TypeTag>
-struct PrintProperties<TypeTag, Properties::TTag::NumericModel>
-{ static constexpr int value = 2; };
-
 //! The default value for the simulation's restart time
 template<class TypeTag>
 struct RestartTime<TypeTag, Properties::TTag::NumericModel>

--- a/opm/models/utils/propertysystem.hh
+++ b/opm/models/utils/propertysystem.hh
@@ -268,17 +268,6 @@ auto getPropName()
 #pragma clang diagnostic pop
 #endif
 
-namespace Properties {
-template <class TypeTag>
-void printValues(std::ostream& os)
-{
-    os <<
-    "The eWoms property system was compiled with the macro\n"
-    "NO_PROPERTY_INTROSPECTION defined.\n"
-    "No diagnostic messages this time, sorry.\n";
-}
-}
-
 } // end namespace Opm
 
 #endif

--- a/opm/models/utils/start.hh
+++ b/opm/models/utils/start.hh
@@ -80,9 +80,6 @@ static inline void registerAllParameters_(bool finalizeRegistration = true)
 
     Parameters::registerParam<TypeTag, Parameters::ParameterFile>
         ("An .ini file which contains a set of run-time parameters");
-    Parameters::registerParam<TypeTag, Parameters::PrintProperties>
-        ("Print the values of the compile time properties at "
-         "the start of the simulation");
     Parameters::registerParam<TypeTag, Parameters::PrintParameters>
         ("Print the values of the run-time parameters at the "
          "start of the simulation");
@@ -375,13 +372,6 @@ static inline int start(int argc, char **argv,  bool registerParams=true)
                 // always print the list of specified but unused parameters
                 if (Parameters::printUnused<TypeTag>())
                     std::cout << endParametersSeparator;
-        }
-
-        // print the properties if requested
-        int printProps = Parameters::get<TypeTag, Parameters::PrintProperties>();
-        if (printProps && myRank == 0) {
-            if (printProps == 1 || !isatty(fileno(stdout)))
-                Properties::printValues<TypeTag>(std::cout);
         }
 
         // instantiate and run the concrete problem. make sure to


### PR DESCRIPTION
property introspection is not supported and unlikely to return.

this has not been supported since the property/typetag system was changed from the old macro based implementation, ie, for the last 5 years. since the new system is based on partial specialization of structs, this is unlikely to ever return since we'd need reflection support to implement it.